### PR TITLE
Add state transition validation for workflow artifacts

### DIFF
--- a/.claude/commands/chunk-complete.md
+++ b/.claude/commands/chunk-complete.md
@@ -86,6 +86,9 @@ search for it - run it directly via Bash.
     recommendations based on each overlapping subsystem's status. For semantic changes,
     always get operator confirmation before expanding scope or updating subsystem documentation.
 
-11. Mark the chunk status as active in the front matter and remove the comment
-    explaining the structure of the front matter from the <chunk
-    directory>/GOAL.md file
+11. Update the chunk status to ACTIVE using the CLI command:
+    ```
+    ve chunk status <chunk_id> ACTIVE
+    ```
+    Then remove the comment explaining the structure of the front matter from the
+    <chunk directory>/GOAL.md file

--- a/.claude/commands/investigation-create.md
+++ b/.claude/commands/investigation-create.md
@@ -105,7 +105,7 @@ If the task warrants investigation:
    > **To continue exploring**: Work through hypotheses in the Exploration Log
    > **To document findings**: Update the Findings section as you verify/falsify
    > **To propose work**: Add chunk prompts to Proposed Chunks when action items emerge
-   > **To resolve**: Update status to SOLVED, NOTED, or DEFERRED when complete"
+   > **To resolve**: Use `ve investigation status <investigation_id> <STATUS>` where STATUS is SOLVED, NOTED, or DEFERRED"
 
 ---
 

--- a/docs/chunks/valid_transitions/GOAL.md
+++ b/docs/chunks/valid_transitions/GOAL.md
@@ -1,0 +1,130 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+- src/models.py
+- src/chunks.py
+- src/narratives.py
+- src/investigations.py
+- src/ve.py
+- .claude/commands/chunk-complete.md
+- .claude/commands/investigation-create.md
+- docs/subsystems/workflow_artifacts/OVERVIEW.md
+- tests/test_transitions.py
+code_references:
+- ref: src/models.py#VALID_CHUNK_TRANSITIONS
+  implements: Chunk state transition rules (FUTURE->IMPLEMENTING->ACTIVE->SUPERSEDED->HISTORICAL)
+- ref: src/models.py#VALID_NARRATIVE_TRANSITIONS
+  implements: Narrative state transition rules (DRAFTING->ACTIVE->COMPLETED)
+- ref: src/models.py#VALID_INVESTIGATION_TRANSITIONS
+  implements: Investigation state transition rules (ONGOING->SOLVED/NOTED/DEFERRED)
+- ref: src/chunks.py#Chunks::get_status
+  implements: Get current chunk status from frontmatter
+- ref: src/chunks.py#Chunks::update_status
+  implements: Update chunk status with transition validation
+- ref: src/narratives.py#Narratives::get_status
+  implements: Get current narrative status from frontmatter
+- ref: src/narratives.py#Narratives::update_status
+  implements: Update narrative status with transition validation
+- ref: src/narratives.py#Narratives::_update_overview_frontmatter
+  implements: Helper to update OVERVIEW.md frontmatter fields
+- ref: src/investigations.py#Investigations::get_status
+  implements: Get current investigation status from frontmatter
+- ref: src/investigations.py#Investigations::update_status
+  implements: Update investigation status with transition validation
+- ref: src/investigations.py#Investigations::_update_overview_frontmatter
+  implements: Helper to update OVERVIEW.md frontmatter fields
+- ref: tests/test_transitions.py
+  implements: Tests for transition dict structure and CLI commands
+narrative: null
+subsystems:
+- subsystem_id: workflow_artifacts
+  relationship: implements
+created_after:
+- external_chunk_causal
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Add explicit state transition validation for chunks, narratives, and investigations to `models.py`, following the pattern established by `VALID_STATUS_TRANSITIONS` for subsystems.
+
+Currently, only subsystems have code-level state transition validation. This creates a gap where invalid lifecycle transitions (e.g., marking a FUTURE chunk as HISTORICAL without going through IMPLEMENTING/ACTIVE) can occur without runtime validation. This violates the workflow_artifacts subsystem's Hard Invariant #10: "Status transitions must be defined in both template and code."
+
+This chunk addresses the "No Code-Level State Transitions" known deviation in the workflow_artifacts subsystem by:
+
+1. **Adding transition dicts to `models.py`**:
+   - `VALID_CHUNK_TRANSITIONS` - defining valid state paths for chunks
+   - `VALID_NARRATIVE_TRANSITIONS` - defining valid state paths for narratives
+   - `VALID_INVESTIGATION_TRANSITIONS` - defining valid state paths for investigations
+
+2. **Adding manager class methods** (following the subsystems pattern):
+   - `Chunks.get_status()`, `Chunks.update_status()`
+   - `Narratives.get_status()`, `Narratives.update_status()`
+   - `Investigations.get_status()`, `Investigations.update_status()`
+
+3. **Adding CLI commands**:
+   - `ve chunk status [chunk_id] [new_status]` - show/update chunk status
+   - `ve narrative status [narrative_id] [new_status]` - show/update narrative status
+   - `ve investigation status [investigation_id] [new_status]` - show/update investigation status
+
+4. **Updating slash commands** to use official status commands instead of direct frontmatter editing:
+   - `/chunk-complete` - use `ve chunk status` for IMPLEMENTING → ACTIVE
+   - `/investigation-create` - reference `ve investigation status` for resolution
+
+This enables runtime validation of lifecycle transitions and ensures agents cannot accidentally put artifacts into invalid states.
+
+## Success Criteria
+
+### Transition Dicts in models.py
+
+1. `VALID_CHUNK_TRANSITIONS` dict exists mapping each `ChunkStatus` to its valid next states:
+   - FUTURE → {IMPLEMENTING, HISTORICAL}
+   - IMPLEMENTING → {ACTIVE, HISTORICAL}
+   - ACTIVE → {SUPERSEDED, HISTORICAL}
+   - SUPERSEDED → {HISTORICAL}
+   - HISTORICAL → {} (terminal)
+
+2. `VALID_NARRATIVE_TRANSITIONS` dict exists mapping each `NarrativeStatus` to its valid next states:
+   - DRAFTING → {ACTIVE}
+   - ACTIVE → {COMPLETED}
+   - COMPLETED → {} (terminal)
+
+3. `VALID_INVESTIGATION_TRANSITIONS` dict exists mapping each `InvestigationStatus` to its valid next states:
+   - ONGOING → {SOLVED, NOTED, DEFERRED}
+   - SOLVED → {} (terminal)
+   - NOTED → {} (terminal)
+   - DEFERRED → {ONGOING} (can be resumed)
+
+### Manager Class Methods
+
+4. `Chunks` class has `get_status(chunk_id)` and `update_status(chunk_id, new_status)` methods following the subsystems pattern
+
+5. `Narratives` class has `get_status(narrative_id)` and `update_status(narrative_id, new_status)` methods
+
+6. `Investigations` class has `get_status(investigation_id)` and `update_status(investigation_id, new_status)` methods
+
+7. All `update_status()` methods validate transitions against their respective `VALID_*_TRANSITIONS` dict
+
+### CLI Commands
+
+8. `ve chunk status [chunk_id] [new_status]` command exists - shows status without new_status arg, updates with validation when provided
+
+9. `ve narrative status [narrative_id] [new_status]` command exists with same pattern
+
+10. `ve investigation status [investigation_id] [new_status]` command exists with same pattern
+
+### Slash Command Updates
+
+11. `/chunk-complete` (`.claude/commands/chunk-complete.md`) step 11 updated to use `ve chunk status <chunk_id> ACTIVE` instead of direct frontmatter editing
+
+12. `/investigation-create` (`.claude/commands/investigation-create.md`) step 6 updated to reference `ve investigation status` for resolution
+
+### Verification
+
+13. All tests pass (`uv run pytest tests/`)
+
+14. The workflow_artifacts subsystem's "No Code-Level State Transitions" known deviation is marked as RESOLVED
+

--- a/docs/chunks/valid_transitions/PLAN.md
+++ b/docs/chunks/valid_transitions/PLAN.md
@@ -1,0 +1,237 @@
+# Implementation Plan
+
+## Approach
+
+Follow the established pattern from subsystems, which has the canonical implementation:
+
+1. **Transition dicts in `models.py`** - Define `VALID_*_TRANSITIONS` dicts after each status enum, using the same structure as `VALID_STATUS_TRANSITIONS` (dict mapping status to set of valid next statuses)
+
+2. **Manager class methods** - Add `get_status()` and `update_status()` to each manager class:
+   - `get_status(artifact_id)` - Parse frontmatter and return status enum
+   - `update_status(artifact_id, new_status)` - Validate transition and update frontmatter
+   - Use `task_utils.update_frontmatter_field()` for chunks (GOAL.md), add `_update_overview_frontmatter()` to narratives/investigations (OVERVIEW.md)
+
+3. **CLI commands** - Add `status` subcommand to each command group following the subsystem pattern:
+   - Display mode: `ve {type} status {id}` shows current status
+   - Transition mode: `ve {type} status {id} {new_status}` validates and updates
+
+4. **Slash command updates** - Update guidance to use CLI commands instead of direct editing
+
+## Subsystem Considerations
+
+- **docs/subsystems/workflow_artifacts** (REFACTORING): This chunk IMPLEMENTS the subsystem by adding transition validation for chunks, narratives, and investigations. The subsystem is in REFACTORING status, so this chunk actively addresses the "No Code-Level State Transitions" known deviation.
+
+## Sequence
+
+### Step 1: Add transition dicts to models.py
+
+Add `VALID_CHUNK_TRANSITIONS`, `VALID_NARRATIVE_TRANSITIONS`, and `VALID_INVESTIGATION_TRANSITIONS` dicts to `src/models.py`, placed immediately after their respective status enums.
+
+**VALID_CHUNK_TRANSITIONS** (after `ChunkStatus`):
+```python
+VALID_CHUNK_TRANSITIONS: dict[ChunkStatus, set[ChunkStatus]] = {
+    ChunkStatus.FUTURE: {ChunkStatus.IMPLEMENTING, ChunkStatus.HISTORICAL},
+    ChunkStatus.IMPLEMENTING: {ChunkStatus.ACTIVE, ChunkStatus.HISTORICAL},
+    ChunkStatus.ACTIVE: {ChunkStatus.SUPERSEDED, ChunkStatus.HISTORICAL},
+    ChunkStatus.SUPERSEDED: {ChunkStatus.HISTORICAL},
+    ChunkStatus.HISTORICAL: set(),  # Terminal state
+}
+```
+
+**VALID_NARRATIVE_TRANSITIONS** (after `NarrativeStatus`):
+```python
+VALID_NARRATIVE_TRANSITIONS: dict[NarrativeStatus, set[NarrativeStatus]] = {
+    NarrativeStatus.DRAFTING: {NarrativeStatus.ACTIVE},
+    NarrativeStatus.ACTIVE: {NarrativeStatus.COMPLETED},
+    NarrativeStatus.COMPLETED: set(),  # Terminal state
+}
+```
+
+**VALID_INVESTIGATION_TRANSITIONS** (after `InvestigationStatus`):
+```python
+VALID_INVESTIGATION_TRANSITIONS: dict[InvestigationStatus, set[InvestigationStatus]] = {
+    InvestigationStatus.ONGOING: {InvestigationStatus.SOLVED, InvestigationStatus.NOTED, InvestigationStatus.DEFERRED},
+    InvestigationStatus.SOLVED: set(),  # Terminal state
+    InvestigationStatus.NOTED: set(),  # Terminal state
+    InvestigationStatus.DEFERRED: {InvestigationStatus.ONGOING},  # Can resume
+}
+```
+
+Location: `src/models.py`
+
+Add backreference comment: `# Chunk: docs/chunks/valid_transitions - State transition validation`
+
+### Step 2: Add get_status() and update_status() to Chunks class
+
+Add methods to `src/chunks.py` following the subsystems pattern:
+
+1. `get_status(chunk_id: str) -> ChunkStatus` - Parse frontmatter and return status
+2. `update_status(chunk_id: str, new_status: ChunkStatus) -> tuple[ChunkStatus, ChunkStatus]` - Validate transition using `VALID_CHUNK_TRANSITIONS`, update via `task_utils.update_frontmatter_field()`, return (old, new)
+
+Import `VALID_CHUNK_TRANSITIONS` from `models.py`.
+
+Location: `src/chunks.py`
+
+Add backreference comment on both methods.
+
+### Step 3: Add get_status() and update_status() to Narratives class
+
+Add methods to `src/narratives.py`:
+
+1. `get_status(narrative_id: str) -> NarrativeStatus` - Parse frontmatter and return status
+2. `update_status(narrative_id: str, new_status: NarrativeStatus) -> tuple[NarrativeStatus, NarrativeStatus]` - Validate transition, update OVERVIEW.md frontmatter
+3. `_update_overview_frontmatter(narrative_id: str, field: str, value) -> None` - Helper to update frontmatter (copy pattern from subsystems.py)
+
+Import `VALID_NARRATIVE_TRANSITIONS` and `NarrativeStatus` from `models.py`.
+
+Location: `src/narratives.py`
+
+### Step 4: Add get_status() and update_status() to Investigations class
+
+Add methods to `src/investigations.py`:
+
+1. `get_status(investigation_id: str) -> InvestigationStatus` - Parse frontmatter and return status
+2. `update_status(investigation_id: str, new_status: InvestigationStatus) -> tuple[InvestigationStatus, InvestigationStatus]` - Validate transition, update OVERVIEW.md frontmatter
+3. `_update_overview_frontmatter(investigation_id: str, field: str, value) -> None` - Helper to update frontmatter
+
+Import `VALID_INVESTIGATION_TRANSITIONS` and `InvestigationStatus` from `models.py`.
+
+Location: `src/investigations.py`
+
+### Step 5: Add `ve chunk status` CLI command
+
+Add status command to the chunk command group in `src/ve.py`:
+
+```python
+@chunk.command()
+@click.argument("chunk_id")
+@click.argument("new_status", required=False, default=None)
+@click.option("--project-dir", ...)
+def status(chunk_id, new_status, project_dir):
+    """Show or update chunk status."""
+```
+
+Follow the subsystem `status` command pattern:
+- Display mode when `new_status` is None
+- Transition mode when `new_status` is provided
+- Resolve chunk_id using `chunks.resolve_chunk_id()`
+- Use `extract_short_name()` for display
+- Handle `ValueError` from `update_status()` for invalid transitions
+
+Import `ChunkStatus` from `models`.
+
+Location: `src/ve.py`
+
+### Step 6: Add `ve narrative status` CLI command
+
+Add status command to the narrative command group in `src/ve.py`:
+
+```python
+@narrative.command()
+@click.argument("narrative_id")
+@click.argument("new_status", required=False, default=None)
+@click.option("--project-dir", ...)
+def status(narrative_id, new_status, project_dir):
+    """Show or update narrative status."""
+```
+
+Import `NarrativeStatus` from `models`.
+
+Location: `src/ve.py`
+
+### Step 7: Add `ve investigation status` CLI command
+
+Add status command to the investigation command group in `src/ve.py`:
+
+```python
+@investigation.command()
+@click.argument("investigation_id")
+@click.argument("new_status", required=False, default=None)
+@click.option("--project-dir", ...)
+def status(investigation_id, new_status, project_dir):
+    """Show or update investigation status."""
+```
+
+Import `InvestigationStatus` from `models`.
+
+Location: `src/ve.py`
+
+### Step 8: Update /chunk-complete slash command
+
+Update `.claude/commands/chunk-complete.md` step 11:
+
+**Before:**
+> Mark the chunk status as active in the front matter and remove the comment explaining the structure...
+
+**After:**
+> Update the chunk status to ACTIVE using the CLI command:
+> ```
+> ve chunk status <chunk_id> ACTIVE
+> ```
+> Then remove the comment explaining the structure of the front matter from the <chunk directory>/GOAL.md file
+
+Location: `.claude/commands/chunk-complete.md`
+
+### Step 9: Update /investigation-create slash command
+
+Update `.claude/commands/investigation-create.md` step 6 to reference the status command:
+
+**Before:**
+> **To resolve**: Update status to SOLVED, NOTED, or DEFERRED when complete
+
+**After:**
+> **To resolve**: Use `ve investigation status <investigation_id> <STATUS>` where STATUS is SOLVED, NOTED, or DEFERRED
+
+Location: `.claude/commands/investigation-create.md`
+
+### Step 10: Add tests for transition validation
+
+Add tests to verify:
+1. Transition dicts have correct structure (all statuses have an entry)
+2. Valid transitions are accepted
+3. Invalid transitions are rejected with appropriate error messages
+4. Terminal states have empty transition sets
+
+Location: `tests/test_models.py` or new `tests/test_transitions.py`
+
+### Step 11: Update workflow_artifacts subsystem documentation
+
+Mark the "No Code-Level State Transitions" known deviation as RESOLVED in `docs/subsystems/workflow_artifacts/OVERVIEW.md`:
+
+1. Update the Known Deviations section to mark this as resolved
+2. Add this chunk to the `chunks` frontmatter array with `relationship: implements`
+
+Location: `docs/subsystems/workflow_artifacts/OVERVIEW.md`
+
+### Step 12: Run tests and verify
+
+Run `uv run pytest tests/` to verify all tests pass.
+
+Manually verify each CLI command works:
+- `ve chunk status valid_transitions` (should show IMPLEMENTING)
+- `ve narrative status` / `ve investigation status` with test artifacts
+
+## Dependencies
+
+None. All required infrastructure exists:
+- Status enums are already defined in `models.py`
+- Manager classes exist with `parse_*_frontmatter()` methods
+- CLI command groups exist in `ve.py`
+- `task_utils.update_frontmatter_field()` exists for GOAL.md updates
+- `Subsystems._update_overview_frontmatter()` exists as a pattern to follow
+
+## Risks and Open Questions
+
+1. **Existing code using activate_chunk()** - The `Chunks.activate_chunk()` method already performs FUTURE→IMPLEMENTING transitions. The new `update_status()` should handle all transitions including this one. Consider whether to:
+   - Keep `activate_chunk()` as a convenience wrapper that calls `update_status()`
+   - Deprecate `activate_chunk()` in favor of `update_status()`
+
+   **Decision**: Keep `activate_chunk()` for now as it has additional logic (checking for existing IMPLEMENTING chunk). It can internally use the transition validation but doesn't need to call `update_status()` directly.
+
+2. **Narrative/Investigation ID resolution** - Unlike chunks which have `resolve_chunk_id()`, narratives and investigations don't have equivalent methods. The CLI commands will need to handle both full directory names and short names.
+
+   **Mitigation**: Add simple resolution logic in the CLI command or add `resolve_*_id()` methods to the manager classes.
+
+## Deviations
+
+(To be populated during implementation)

--- a/src/models.py
+++ b/src/models.py
@@ -38,6 +38,15 @@ class InvestigationStatus(StrEnum):
     DEFERRED = "DEFERRED"  # Investigation paused; may be revisited later
 
 
+# Chunk: docs/chunks/valid_transitions - State transition validation
+VALID_INVESTIGATION_TRANSITIONS: dict[InvestigationStatus, set[InvestigationStatus]] = {
+    InvestigationStatus.ONGOING: {InvestigationStatus.SOLVED, InvestigationStatus.NOTED, InvestigationStatus.DEFERRED},
+    InvestigationStatus.SOLVED: set(),  # Terminal state
+    InvestigationStatus.NOTED: set(),  # Terminal state
+    InvestigationStatus.DEFERRED: {InvestigationStatus.ONGOING},  # Can resume
+}
+
+
 # Chunk: docs/chunks/chunk_frontmatter_model - Chunk lifecycle states
 class ChunkStatus(StrEnum):
     """Status values for chunk lifecycle."""
@@ -47,6 +56,16 @@ class ChunkStatus(StrEnum):
     ACTIVE = "ACTIVE"  # Accurately describes current or recently-merged work
     SUPERSEDED = "SUPERSEDED"  # Another chunk has modified the code this chunk governed
     HISTORICAL = "HISTORICAL"  # Significant drift; kept for archaeology only
+
+
+# Chunk: docs/chunks/valid_transitions - State transition validation
+VALID_CHUNK_TRANSITIONS: dict[ChunkStatus, set[ChunkStatus]] = {
+    ChunkStatus.FUTURE: {ChunkStatus.IMPLEMENTING, ChunkStatus.HISTORICAL},
+    ChunkStatus.IMPLEMENTING: {ChunkStatus.ACTIVE, ChunkStatus.HISTORICAL},
+    ChunkStatus.ACTIVE: {ChunkStatus.SUPERSEDED, ChunkStatus.HISTORICAL},
+    ChunkStatus.SUPERSEDED: {ChunkStatus.HISTORICAL},
+    ChunkStatus.HISTORICAL: set(),  # Terminal state
+}
 
 
 # Chunk: docs/chunks/subsystem_status_transitions - Valid state transitions
@@ -407,6 +426,14 @@ class NarrativeStatus(StrEnum):
     DRAFTING = "DRAFTING"  # Narrative is being refined; chunks not yet created
     ACTIVE = "ACTIVE"  # Chunks are being created and implemented
     COMPLETED = "COMPLETED"  # All chunks created and narrative's ambition realized
+
+
+# Chunk: docs/chunks/valid_transitions - State transition validation
+VALID_NARRATIVE_TRANSITIONS: dict[NarrativeStatus, set[NarrativeStatus]] = {
+    NarrativeStatus.DRAFTING: {NarrativeStatus.ACTIVE},
+    NarrativeStatus.ACTIVE: {NarrativeStatus.COMPLETED},
+    NarrativeStatus.COMPLETED: set(),  # Terminal state
+}
 
 
 # Chunk: docs/chunks/proposed_chunks_frontmatter - Narrative frontmatter schema

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,531 @@
+"""Tests for state transition validation across workflow artifacts.
+
+Chunk: docs/chunks/valid_transitions - State transition validation
+"""
+
+import pytest
+
+from models import (
+    ChunkStatus,
+    NarrativeStatus,
+    InvestigationStatus,
+    VALID_CHUNK_TRANSITIONS,
+    VALID_NARRATIVE_TRANSITIONS,
+    VALID_INVESTIGATION_TRANSITIONS,
+)
+from ve import cli
+
+
+# =============================================================================
+# Transition Dict Structure Tests
+# =============================================================================
+
+
+class TestTransitionDictStructure:
+    """Verify transition dicts have correct structure."""
+
+    def test_chunk_transitions_has_all_statuses(self):
+        """Every ChunkStatus has an entry in VALID_CHUNK_TRANSITIONS."""
+        for status in ChunkStatus:
+            assert status in VALID_CHUNK_TRANSITIONS, f"Missing entry for {status}"
+
+    def test_narrative_transitions_has_all_statuses(self):
+        """Every NarrativeStatus has an entry in VALID_NARRATIVE_TRANSITIONS."""
+        for status in NarrativeStatus:
+            assert status in VALID_NARRATIVE_TRANSITIONS, f"Missing entry for {status}"
+
+    def test_investigation_transitions_has_all_statuses(self):
+        """Every InvestigationStatus has an entry in VALID_INVESTIGATION_TRANSITIONS."""
+        for status in InvestigationStatus:
+            assert status in VALID_INVESTIGATION_TRANSITIONS, f"Missing entry for {status}"
+
+    def test_chunk_terminal_state_has_empty_set(self):
+        """HISTORICAL has no valid transitions (terminal state)."""
+        assert VALID_CHUNK_TRANSITIONS[ChunkStatus.HISTORICAL] == set()
+
+    def test_narrative_terminal_state_has_empty_set(self):
+        """COMPLETED has no valid transitions (terminal state)."""
+        assert VALID_NARRATIVE_TRANSITIONS[NarrativeStatus.COMPLETED] == set()
+
+    def test_investigation_terminal_states_have_empty_set(self):
+        """SOLVED and NOTED have no valid transitions (terminal states)."""
+        assert VALID_INVESTIGATION_TRANSITIONS[InvestigationStatus.SOLVED] == set()
+        assert VALID_INVESTIGATION_TRANSITIONS[InvestigationStatus.NOTED] == set()
+
+    def test_investigation_deferred_can_resume(self):
+        """DEFERRED can transition back to ONGOING."""
+        assert InvestigationStatus.ONGOING in VALID_INVESTIGATION_TRANSITIONS[InvestigationStatus.DEFERRED]
+
+
+class TestChunkTransitionValues:
+    """Verify chunk transition values are correct."""
+
+    def test_future_transitions(self):
+        """FUTURE -> {IMPLEMENTING, HISTORICAL}"""
+        expected = {ChunkStatus.IMPLEMENTING, ChunkStatus.HISTORICAL}
+        assert VALID_CHUNK_TRANSITIONS[ChunkStatus.FUTURE] == expected
+
+    def test_implementing_transitions(self):
+        """IMPLEMENTING -> {ACTIVE, HISTORICAL}"""
+        expected = {ChunkStatus.ACTIVE, ChunkStatus.HISTORICAL}
+        assert VALID_CHUNK_TRANSITIONS[ChunkStatus.IMPLEMENTING] == expected
+
+    def test_active_transitions(self):
+        """ACTIVE -> {SUPERSEDED, HISTORICAL}"""
+        expected = {ChunkStatus.SUPERSEDED, ChunkStatus.HISTORICAL}
+        assert VALID_CHUNK_TRANSITIONS[ChunkStatus.ACTIVE] == expected
+
+    def test_superseded_transitions(self):
+        """SUPERSEDED -> {HISTORICAL}"""
+        expected = {ChunkStatus.HISTORICAL}
+        assert VALID_CHUNK_TRANSITIONS[ChunkStatus.SUPERSEDED] == expected
+
+
+class TestNarrativeTransitionValues:
+    """Verify narrative transition values are correct."""
+
+    def test_drafting_transitions(self):
+        """DRAFTING -> {ACTIVE}"""
+        expected = {NarrativeStatus.ACTIVE}
+        assert VALID_NARRATIVE_TRANSITIONS[NarrativeStatus.DRAFTING] == expected
+
+    def test_active_transitions(self):
+        """ACTIVE -> {COMPLETED}"""
+        expected = {NarrativeStatus.COMPLETED}
+        assert VALID_NARRATIVE_TRANSITIONS[NarrativeStatus.ACTIVE] == expected
+
+
+class TestInvestigationTransitionValues:
+    """Verify investigation transition values are correct."""
+
+    def test_ongoing_transitions(self):
+        """ONGOING -> {SOLVED, NOTED, DEFERRED}"""
+        expected = {InvestigationStatus.SOLVED, InvestigationStatus.NOTED, InvestigationStatus.DEFERRED}
+        assert VALID_INVESTIGATION_TRANSITIONS[InvestigationStatus.ONGOING] == expected
+
+    def test_deferred_transitions(self):
+        """DEFERRED -> {ONGOING}"""
+        expected = {InvestigationStatus.ONGOING}
+        assert VALID_INVESTIGATION_TRANSITIONS[InvestigationStatus.DEFERRED] == expected
+
+
+# =============================================================================
+# Chunk Status CLI Tests
+# =============================================================================
+
+
+class TestChunkStatusDisplay:
+    """Tests for 've chunk status <id>' (display mode)."""
+
+    def test_status_display_shows_current_status(self, runner, temp_project):
+        """Show current status for an existing chunk."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "validation: IMPLEMENTING" in result.output
+
+
+class TestChunkStatusTransitions:
+    """Tests for valid and invalid chunk status transitions."""
+
+    def test_valid_transition_implementing_to_active(self, runner, temp_project):
+        """IMPLEMENTING -> ACTIVE works."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "ACTIVE", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "validation: IMPLEMENTING" in result.output
+        assert "ACTIVE" in result.output
+
+    def test_valid_transition_future_to_implementing(self, runner, temp_project):
+        """FUTURE -> IMPLEMENTING works."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--future", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "IMPLEMENTING", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "validation: FUTURE" in result.output
+        assert "IMPLEMENTING" in result.output
+
+    def test_valid_transition_active_to_superseded(self, runner, temp_project):
+        """ACTIVE -> SUPERSEDED works."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "ACTIVE", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "SUPERSEDED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "ACTIVE" in result.output
+        assert "SUPERSEDED" in result.output
+
+    def test_invalid_transition_implementing_to_superseded(self, runner, temp_project):
+        """Cannot skip steps: IMPLEMENTING -> SUPERSEDED fails."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "SUPERSEDED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from IMPLEMENTING to SUPERSEDED" in result.output
+        assert "Valid transitions:" in result.output
+
+    def test_invalid_transition_historical_to_any(self, runner, temp_project):
+        """Terminal state enforced: HISTORICAL -> any fails."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "HISTORICAL", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "ACTIVE", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from HISTORICAL" in result.output
+        assert "terminal state" in result.output
+
+
+class TestChunkStatusErrors:
+    """Tests for chunk status error handling."""
+
+    def test_chunk_not_found_error(self, runner, temp_project):
+        """Clear error message when chunk doesn't exist."""
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "nonexistent", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Chunk 'nonexistent' not found" in result.output
+
+    def test_invalid_status_value_error(self, runner, temp_project):
+        """Lists valid statuses when invalid status provided."""
+        runner.invoke(
+            cli,
+            ["chunk", "start", "validation", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["chunk", "status", "validation", "FOO", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Invalid status 'FOO'" in result.output
+        assert "IMPLEMENTING" in result.output
+        assert "ACTIVE" in result.output
+
+
+# =============================================================================
+# Narrative Status CLI Tests
+# =============================================================================
+
+
+class TestNarrativeStatusDisplay:
+    """Tests for 've narrative status <id>' (display mode)."""
+
+    def test_status_display_shows_current_status(self, runner, temp_project):
+        """Show current status for an existing narrative."""
+        runner.invoke(
+            cli,
+            ["narrative", "create", "migration", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "migration: DRAFTING" in result.output
+
+
+class TestNarrativeStatusTransitions:
+    """Tests for valid and invalid narrative status transitions."""
+
+    def test_valid_transition_drafting_to_active(self, runner, temp_project):
+        """DRAFTING -> ACTIVE works."""
+        runner.invoke(
+            cli,
+            ["narrative", "create", "migration", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "ACTIVE", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "migration: DRAFTING" in result.output
+        assert "ACTIVE" in result.output
+
+    def test_valid_transition_active_to_completed(self, runner, temp_project):
+        """ACTIVE -> COMPLETED works."""
+        runner.invoke(
+            cli,
+            ["narrative", "create", "migration", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "ACTIVE", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "COMPLETED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "ACTIVE" in result.output
+        assert "COMPLETED" in result.output
+
+    def test_invalid_transition_drafting_to_completed(self, runner, temp_project):
+        """Cannot skip steps: DRAFTING -> COMPLETED fails."""
+        runner.invoke(
+            cli,
+            ["narrative", "create", "migration", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "COMPLETED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from DRAFTING to COMPLETED" in result.output
+        assert "Valid transitions:" in result.output
+
+    def test_invalid_transition_completed_to_any(self, runner, temp_project):
+        """Terminal state enforced: COMPLETED -> any fails."""
+        runner.invoke(
+            cli,
+            ["narrative", "create", "migration", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "ACTIVE", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "COMPLETED", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "DRAFTING", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from COMPLETED" in result.output
+        assert "terminal state" in result.output
+
+
+class TestNarrativeStatusErrors:
+    """Tests for narrative status error handling."""
+
+    def test_narrative_not_found_error(self, runner, temp_project):
+        """Clear error message when narrative doesn't exist."""
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "nonexistent", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Narrative 'nonexistent' not found" in result.output
+
+    def test_invalid_status_value_error(self, runner, temp_project):
+        """Lists valid statuses when invalid status provided."""
+        runner.invoke(
+            cli,
+            ["narrative", "create", "migration", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["narrative", "status", "migration", "FOO", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Invalid status 'FOO'" in result.output
+        assert "DRAFTING" in result.output
+        assert "ACTIVE" in result.output
+
+
+# =============================================================================
+# Investigation Status CLI Tests
+# =============================================================================
+
+
+class TestInvestigationStatusDisplay:
+    """Tests for 've investigation status <id>' (display mode)."""
+
+    def test_status_display_shows_current_status(self, runner, temp_project):
+        """Show current status for an existing investigation."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "memory_leak: ONGOING" in result.output
+
+
+class TestInvestigationStatusTransitions:
+    """Tests for valid and invalid investigation status transitions."""
+
+    def test_valid_transition_ongoing_to_solved(self, runner, temp_project):
+        """ONGOING -> SOLVED works."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "SOLVED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "memory_leak: ONGOING" in result.output
+        assert "SOLVED" in result.output
+
+    def test_valid_transition_ongoing_to_noted(self, runner, temp_project):
+        """ONGOING -> NOTED works."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "NOTED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "ONGOING" in result.output
+        assert "NOTED" in result.output
+
+    def test_valid_transition_ongoing_to_deferred(self, runner, temp_project):
+        """ONGOING -> DEFERRED works."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "DEFERRED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "ONGOING" in result.output
+        assert "DEFERRED" in result.output
+
+    def test_valid_transition_deferred_to_ongoing(self, runner, temp_project):
+        """DEFERRED -> ONGOING (resume) works."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "DEFERRED", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "ONGOING", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 0
+        assert "DEFERRED" in result.output
+        assert "ONGOING" in result.output
+
+    def test_invalid_transition_solved_to_any(self, runner, temp_project):
+        """Terminal state enforced: SOLVED -> any fails."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "SOLVED", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "ONGOING", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from SOLVED" in result.output
+        assert "terminal state" in result.output
+
+    def test_invalid_transition_noted_to_any(self, runner, temp_project):
+        """Terminal state enforced: NOTED -> any fails."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "NOTED", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "ONGOING", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from NOTED" in result.output
+        assert "terminal state" in result.output
+
+    def test_invalid_transition_deferred_to_solved(self, runner, temp_project):
+        """DEFERRED -> SOLVED fails (must resume first)."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "DEFERRED", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "SOLVED", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Cannot transition from DEFERRED to SOLVED" in result.output
+        assert "Valid transitions:" in result.output
+
+
+class TestInvestigationStatusErrors:
+    """Tests for investigation status error handling."""
+
+    def test_investigation_not_found_error(self, runner, temp_project):
+        """Clear error message when investigation doesn't exist."""
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "nonexistent", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Investigation 'nonexistent' not found" in result.output
+
+    def test_invalid_status_value_error(self, runner, temp_project):
+        """Lists valid statuses when invalid status provided."""
+        runner.invoke(
+            cli,
+            ["investigation", "create", "memory_leak", "--project-dir", str(temp_project)]
+        )
+        result = runner.invoke(
+            cli,
+            ["investigation", "status", "memory_leak", "FOO", "--project-dir", str(temp_project)]
+        )
+        assert result.exit_code == 1
+        assert "Invalid status 'FOO'" in result.output
+        assert "ONGOING" in result.output
+        assert "SOLVED" in result.output


### PR DESCRIPTION
Add explicit code-level state transition validation for chunks, narratives, and investigations, following the pattern established by VALID_STATUS_TRANSITIONS for subsystems. This resolves the "No Code-Level State Transitions" known deviation in the workflow_artifacts subsystem's Hard Invariant #10.

Changes include:
- VALID_CHUNK_TRANSITIONS, VALID_NARRATIVE_TRANSITIONS, and VALID_INVESTIGATION_TRANSITIONS dicts in models.py
- get_status() and update_status() methods in manager classes with transition validation
- ve chunk/narrative/investigation status CLI commands for showing and updating artifact status
- Updated /chunk-complete and /investigation-create slash commands to use the new CLI commands
- Comprehensive test suite verifying transition rules and CLI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)