### PR TITLE
feat: extend ve sync to all workflow artifact types

### DIFF
--- a/docs/chunks/sync_all_workflows/GOAL.md
+++ b/docs/chunks/sync_all_workflows/GOAL.md
@@ -1,0 +1,52 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+- src/sync.py
+- src/ve.py
+- tests/test_sync.py
+- tests/test_sync_cli.py
+code_references:
+  - ref: src/sync.py#SyncResult
+    implements: "SyncResult dataclass with artifact_type field and formatted_id property"
+  - ref: src/sync.py#find_external_refs
+    implements: "Generalized external ref finder that searches all workflow artifact directories"
+  - ref: src/sync.py#sync_task_directory
+    implements: "Task directory sync with artifact type filtering support"
+  - ref: src/sync.py#sync_single_repo
+    implements: "Single repo sync with artifact type filtering support"
+  - ref: src/ve.py#sync
+    implements: "CLI sync command with --type and --artifact options"
+  - ref: src/ve.py#_sync_task_directory
+    implements: "Task directory sync helper with artifact type filtering"
+  - ref: src/ve.py#_sync_single_repo
+    implements: "Single repo sync helper with artifact type filtering"
+  - ref: src/ve.py#_display_sync_results
+    implements: "Display sync results with artifact type prefix"
+narrative: null
+subsystems:
+- subsystem_id: workflow_artifacts
+  relationship: implements
+created_after: ["consolidate_ext_ref_utils"]
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Extend `ve sync` to find and update `external.yaml` files across all workflow artifact directories (`docs/chunks/`, `docs/narratives/`, `docs/investigations/`, `docs/subsystems/`), not just chunks.
+
+Currently, `sync.py` only searches `docs/chunks/` for external references (see `find_external_refs()` at line 39). This limits `ve sync` to chunk-only use, but the `ExternalArtifactRef` model and `external_refs.py` utilities now support all workflow types. This chunk completes the sync functionality to support the full workflow artifact system.
+
+This enables teams using cross-repo workflows for narratives, investigations, or subsystems to keep their pinned SHAs up to date using the same `ve sync` command.
+
+## Success Criteria
+
+- `find_external_refs()` generalized to accept an artifact type parameter (or iterate all types) and search the corresponding directory (`docs/narratives/`, `docs/investigations/`, `docs/subsystems/`)
+- `sync_task_directory()` and `sync_single_repo()` updated to process external references from all artifact type directories
+- `SyncResult` updated to include artifact type information in its output (e.g., `narrative:my_narrative` vs `chunk:my_chunk`)
+- Existing `--chunk` CLI filter option extended or complemented with a more general `--artifact` option
+- Unit tests verify that external.yaml files in each artifact type directory are discovered and synced
+- All existing tests continue to pass (backward compatibility)
+

--- a/docs/chunks/sync_all_workflows/PLAN.md
+++ b/docs/chunks/sync_all_workflows/PLAN.md
@@ -1,0 +1,168 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+Extend the existing sync functionality to iterate over all workflow artifact types instead of just chunks. The key changes are:
+
+1. **Generalize `find_external_refs()`**: Accept an optional `artifact_types` parameter. Default to all types. Use `ARTIFACT_DIR_NAME` from `external_refs.py` to find the correct directory for each type.
+
+2. **Add artifact type to `SyncResult`**: Include `artifact_type` field so output can distinguish between chunk, narrative, investigation, and subsystem syncs.
+
+3. **Update sync functions**: Both `sync_task_directory()` and `sync_single_repo()` will iterate all artifact types, using the generalized finder.
+
+4. **Extend CLI filtering**: Keep `--chunk` for backward compatibility, add `--artifact` option for general filtering by `type:name` pattern.
+
+This builds on the `external_refs.py` utilities created by chunk `consolidate_ext_ref_utils`, using `ARTIFACT_DIR_NAME` and `is_external_artifact()` which already support all artifact types.
+
+## Subsystem Considerations
+
+- **docs/subsystems/workflow_artifacts** (REFACTORING): This chunk IMPLEMENTS the
+  subsystem's External Reference Consolidation item #6 ("Extend ve sync to all
+  workflow types"). The subsystem is in REFACTORING status, so opportunistic
+  improvement applies—we should follow subsystem patterns consistently.
+
+## Sequence
+
+### Step 1: Write failing tests for `find_external_refs` generalization
+
+Add tests to `tests/test_sync.py` verifying:
+- `find_external_refs()` finds external.yaml in `docs/narratives/` directories
+- `find_external_refs()` finds external.yaml in `docs/investigations/` directories
+- `find_external_refs()` finds external.yaml in `docs/subsystems/` directories
+- `find_external_refs()` returns all external refs across all artifact types when no filter specified
+- `find_external_refs()` can filter by artifact type
+
+Location: `tests/test_sync.py`
+
+### Step 2: Generalize `find_external_refs()` function
+
+Update `find_external_refs()` in `src/sync.py` to:
+- Accept optional `artifact_types: list[ArtifactType] | None` parameter (default: all types)
+- Import `ARTIFACT_DIR_NAME` from `external_refs.py` to iterate artifact directories
+- Use `is_external_artifact()` with the appropriate artifact type for each directory
+- Return a list of tuples `(external_yaml_path, artifact_type)` instead of just paths
+
+Location: `src/sync.py`
+
+### Step 3: Write failing tests for `SyncResult` artifact type field
+
+Add tests verifying `SyncResult` includes artifact type:
+- `SyncResult.artifact_type` field exists and is populated
+- Output displays artifact type prefix (e.g., `narrative:my_narrative`)
+
+Location: `tests/test_sync.py`
+
+### Step 4: Add artifact_type field to SyncResult
+
+Update `SyncResult` dataclass in `src/sync.py`:
+- Add `artifact_type: ArtifactType` field
+- Rename `chunk_id` to `artifact_id` for clarity (with deprecation path if needed)
+
+Location: `src/sync.py`
+
+### Step 5: Write failing tests for sync functions with all artifact types
+
+Add tests verifying:
+- `sync_task_directory()` processes external refs from all artifact type directories
+- `sync_single_repo()` processes external refs from all artifact type directories
+- Results include appropriate artifact type for each synced reference
+
+Location: `tests/test_sync.py`
+
+### Step 6: Update `sync_task_directory()` to process all artifact types
+
+Modify the function to:
+- Call generalized `find_external_refs()` for all artifact types
+- Populate `artifact_type` in `SyncResult`
+- Update the chunk_id/artifact_id to use format `{artifact_type.value}:{name}` in task dir mode
+
+Location: `src/sync.py`
+
+### Step 7: Update `sync_single_repo()` to process all artifact types
+
+Modify the function to:
+- Call generalized `find_external_refs()` for all artifact types
+- Populate `artifact_type` in `SyncResult`
+- Update the chunk_id/artifact_id to use format `{artifact_type.value}:{name}` in single repo mode
+
+Location: `src/sync.py`
+
+### Step 8: Write failing tests for CLI filtering
+
+Add tests for CLI options:
+- `--artifact type:name` filters by artifact type and name
+- `--chunk` backward compatibility continues to work (filters to chunk type only)
+- Both filters work correctly together
+
+Location: `tests/test_sync_cli.py`
+
+### Step 9: Extend CLI with `--artifact` option
+
+Update `sync` command in `src/ve.py`:
+- Add `--artifact` option accepting `type:name` or just `name` patterns
+- Keep `--chunk` option for backward compatibility (internally converts to `--artifact chunk:name`)
+- Update `_sync_task_directory()` and `_sync_single_repo()` helper functions to pass artifact filters
+- Update `_display_sync_results()` to show artifact type in output
+
+Location: `src/ve.py`
+
+### Step 10: Update sync function signatures for artifact filtering
+
+Update both sync functions in `src/sync.py`:
+- Replace `chunk_filter` parameter with `artifact_filter: dict[ArtifactType, list[str]] | None`
+- Or simpler: accept `artifact_filter: list[tuple[ArtifactType, str]] | None`
+- Backward compatibility: if only names provided (no type), match across all types
+
+Location: `src/sync.py`
+
+### Step 11: Run all tests and fix any issues
+
+Run `uv run pytest tests/` to verify:
+- All new tests pass
+- All existing tests continue to pass
+- No regressions in sync behavior
+
+Location: All test files
+
+### Step 12: Update module docstring and add backreferences
+
+Update `src/sync.py`:
+- Update module docstring to reflect support for all workflow artifact types
+- Add chunk backreference comment for this chunk
+
+Location: `src/sync.py`
+
+## Dependencies
+
+- **consolidate_ext_ref_utils** (complete) - Provides `ARTIFACT_DIR_NAME`, `is_external_artifact()`,
+  `load_external_ref()` in `src/external_refs.py`
+- **consolidate_ext_refs** (complete) - Provides `ExternalArtifactRef` model with `artifact_type` field
+
+## Risks and Open Questions
+
+- **API backward compatibility**: The `SyncResult.chunk_id` field is used by existing code.
+  May need to keep both `chunk_id` (deprecated) and new `artifact_id` field, or use a single
+  field with different formatting. Decision: Use `artifact_id` as the primary field name,
+  deprecate `chunk_id` if callers exist outside our codebase.
+
+- **CLI option design**: The `--chunk` option exists for filtering. Options considered:
+  1. Keep `--chunk` and add `--narrative`, `--investigation`, `--subsystem` separately
+  2. Add single `--artifact type:name` option and deprecate `--chunk`
+  3. Keep `--chunk` as alias for `--artifact chunk:name`
+
+  Decision: Option 3 - add `--artifact` as the general mechanism, keep `--chunk` for backward
+  compatibility as a convenience alias.
+
+- **Return type change for `find_external_refs()`**: Returning tuples instead of just paths
+  changes the function signature. All callers within the codebase need updating, but since
+  `sync.py` is the only consumer, this is low risk.
+
+## Deviations
+
+<!-- Populated during implementation -->

--- a/docs/subsystems/workflow_artifacts/OVERVIEW.md
+++ b/docs/subsystems/workflow_artifacts/OVERVIEW.md
@@ -51,6 +51,8 @@ chunks:
   relationship: implements
 - chunk_id: consolidate_ext_ref_utils
   relationship: implements
+- chunk_id: sync_all_workflows
+  relationship: implements
 code_references:
 - ref: src/chunks.py#Chunks
   implements: Chunk workflow manager class
@@ -123,6 +125,15 @@ code_references:
   compliance: COMPLIANT
 - ref: src/external_refs.py#load_external_ref
   implements: External reference loading and validation
+  compliance: COMPLIANT
+- ref: src/sync.py#find_external_refs
+  implements: External reference finder for all workflow artifact types
+  compliance: COMPLIANT
+- ref: src/sync.py#sync_task_directory
+  implements: Task directory sync with artifact type filtering
+  compliance: COMPLIANT
+- ref: src/sync.py#sync_single_repo
+  implements: Single repo sync with artifact type filtering
   compliance: COMPLIANT
 - ref: src/ve.py#create
   implements: Chunk creation CLI command
@@ -676,11 +687,11 @@ External chunk references now participate in local causal ordering:
    `detect_artifact_type_from_path()`. Updated all import sites (`sync.py`,
    `external_resolve.py`, `task_utils.py`, `artifact_ordering.py`) to use the new module.
 
-6. **Extend ve sync to all workflow types** - Currently only syncs chunks. Should find
-   and update external.yaml in all workflow artifact directories.
-   - Impact: High
-   - Status: Not yet scheduled
-   - Dependencies: #5
+6. ~~**Extend ve sync to all workflow types**~~ - **RESOLVED** by chunk sync_all_workflows.
+   `ve sync` now finds and updates external.yaml files in all workflow artifact directories
+   (chunks, narratives, investigations, subsystems). Added `--type` option for filtering by
+   artifact type and `--artifact` option for filtering by artifact ID. Existing `--chunk`
+   option maintained for backward compatibility.
 
 7. **Extend ve external resolve to all workflow types** - Currently only resolves chunks.
    Should detect artifact type from path and display appropriate files.

--- a/src/ve.py
+++ b/src/ve.py
@@ -24,7 +24,7 @@ from investigations import Investigations
 from narratives import Narratives
 from project import Project
 from subsystems import Subsystems
-from models import SubsystemStatus, InvestigationStatus, ChunkStatus, NarrativeStatus
+from models import SubsystemStatus, InvestigationStatus, ChunkStatus, NarrativeStatus, ArtifactType
 from task_init import TaskInit
 from task_utils import (
     is_task_directory,
@@ -821,33 +821,56 @@ def status(investigation_id, new_status, project_dir):
 
 
 # Chunk: docs/chunks/ve_sync_command - Sync external references
+# Chunk: docs/chunks/sync_all_workflows - Extended to all workflow artifact types
 @cli.command()
 @click.option("--dry-run", is_flag=True, help="Show what would be updated without making changes")
 @click.option("--project", "projects", multiple=True, help="Sync only specified project(s) (task directory only)")
-@click.option("--chunk", "chunks", multiple=True, help="Sync only specified chunk(s)")
+@click.option("--chunk", "chunks", multiple=True, help="Sync only specified chunk(s) (deprecated, use --artifact)")
+@click.option("--artifact", "artifacts", multiple=True, help="Sync only specified artifact(s)")
+@click.option(
+    "--type", "artifact_type",
+    type=click.Choice(["chunk", "narrative", "investigation", "subsystem"]),
+    help="Sync only specified artifact type"
+)
 @click.option("--project-dir", type=click.Path(exists=True, path_type=pathlib.Path), default=".")
-def sync(dry_run, projects, chunks, project_dir):
-    """Sync external chunk references to current repository state."""
+def sync(dry_run, projects, chunks, artifacts, artifact_type, project_dir):
+    """Sync external artifact references to current repository state.
+
+    Searches for external.yaml files in docs/chunks/, docs/narratives/,
+    docs/investigations/, and docs/subsystems/ directories, then updates
+    their pinned SHA to match the current state of the external repository.
+    """
     # Convert filter tuples to lists (or None if empty)
     project_filter = list(projects) if projects else None
-    chunk_filter = list(chunks) if chunks else None
+
+    # Combine --chunk and --artifact filters for backward compatibility
+    artifact_filter = list(artifacts) if artifacts else []
+    if chunks:
+        artifact_filter.extend(chunks)
+    artifact_filter = artifact_filter if artifact_filter else None
+
+    # Convert artifact type string to ArtifactType
+    artifact_types = None
+    if artifact_type:
+        artifact_types = [ArtifactType(artifact_type)]
 
     # Check if we're in a task directory
     if is_task_directory(project_dir):
-        _sync_task_directory(project_dir, dry_run, project_filter, chunk_filter)
+        _sync_task_directory(project_dir, dry_run, project_filter, artifact_filter, artifact_types)
     else:
         # Single repo mode
         if project_filter:
             click.echo("Error: --project can only be used in task directory context", err=True)
             raise SystemExit(1)
-        _sync_single_repo(project_dir, dry_run, chunk_filter)
+        _sync_single_repo(project_dir, dry_run, artifact_filter, artifact_types)
 
 
 def _sync_task_directory(
     task_dir: pathlib.Path,
     dry_run: bool,
     project_filter: list[str] | None,
-    chunk_filter: list[str] | None,
+    artifact_filter: list[str] | None,
+    artifact_types: list[ArtifactType] | None,
 ):
     """Handle sync in task directory mode."""
     try:
@@ -855,7 +878,8 @@ def _sync_task_directory(
             task_dir,
             dry_run=dry_run,
             project_filter=project_filter,
-            chunk_filter=chunk_filter,
+            artifact_filter=artifact_filter,
+            artifact_types=artifact_types,
         )
     except TaskChunkError as e:
         click.echo(f"Error: {e}", err=True)
@@ -871,11 +895,12 @@ def _sync_task_directory(
 def _sync_single_repo(
     repo_path: pathlib.Path,
     dry_run: bool,
-    chunk_filter: list[str] | None,
+    artifact_filter: list[str] | None,
+    artifact_types: list[ArtifactType] | None,
 ):
     """Handle sync in single repo mode."""
     # Check if there are any external refs
-    external_refs = find_external_refs(repo_path)
+    external_refs = find_external_refs(repo_path, artifact_types=artifact_types)
     if not external_refs:
         click.echo("No external references found")
         return
@@ -883,7 +908,8 @@ def _sync_single_repo(
     results = sync_single_repo(
         repo_path,
         dry_run=dry_run,
-        chunk_filter=chunk_filter,
+        artifact_filter=artifact_filter,
+        artifact_types=artifact_types,
     )
 
     _display_sync_results(results, dry_run)
@@ -896,18 +922,21 @@ def _display_sync_results(results: list, dry_run: bool):
     prefix = "[dry-run] " if dry_run else ""
 
     for result in results:
+        # Format the display ID to include artifact type
+        display_id = f"{result.artifact_type.value}:{result.artifact_id}"
+
         if result.error:
-            click.echo(f"{prefix}Error syncing {result.chunk_id}: {result.error}", err=True)
+            click.echo(f"{prefix}Error syncing {display_id}: {result.error}", err=True)
             error_count += 1
         elif result.updated:
             old_abbrev = result.old_sha[:7] if result.old_sha else "(none)"
             new_abbrev = result.new_sha[:7] if result.new_sha else "(none)"
             verb = "Would update" if dry_run else "Updated"
-            click.echo(f"{prefix}{result.chunk_id}: {old_abbrev} -> {new_abbrev} ({verb})")
+            click.echo(f"{prefix}{display_id}: {old_abbrev} -> {new_abbrev} ({verb})")
             updated_count += 1
         else:
             old_abbrev = result.old_sha[:7] if result.old_sha else "(none)"
-            click.echo(f"{prefix}{result.chunk_id}: {old_abbrev} (already current)")
+            click.echo(f"{prefix}{display_id}: {old_abbrev} (already current)")
 
     # Summary
     total = len(results)


### PR DESCRIPTION
## Summary
- Generalize `ve sync` to find and update external.yaml files across all workflow artifact directories (chunks, narratives, investigations, subsystems)
- Add `artifact_type` field to SyncResult with formatted_id property for type-prefixed output
- Extend CLI with `--type` and `--artifact` options for filtering; maintain `--chunk` for backward compatibility
- Update workflow_artifacts subsystem documentation to mark sync consolidation as resolved

## Test plan
- All existing tests pass, including task directory and single repo sync modes
- New tests verify external.yaml discovery in narratives, investigations, and subsystems directories
- New CLI tests verify --type and --artifact filtering options
- Backward compatibility maintained with --chunk option

🤖 Generated with [Claude Code](https://claude.com/claude-code)