### PR TITLE
feat: add task-aware subsystem discover and list commands

### DIFF
--- a/docs/chunks/task_aware_subsystem_cmds/GOAL.md
+++ b/docs/chunks/task_aware_subsystem_cmds/GOAL.md
@@ -1,0 +1,78 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+- src/models.py
+- src/task_utils.py
+- src/subsystems.py
+- src/ve.py
+- tests/test_task_subsystem_discover.py
+- tests/test_task_subsystem_list.py
+code_references:
+  - ref: src/models.py#SubsystemFrontmatter
+    implements: "Added dependents field to SubsystemFrontmatter for cross-repo subsystem references"
+  - ref: src/task_utils.py#TaskSubsystemError
+    implements: "Error class for user-friendly task subsystem error messages"
+  - ref: src/task_utils.py#add_dependents_to_subsystem
+    implements: "Update subsystem OVERVIEW.md frontmatter with dependents list"
+  - ref: src/task_utils.py#create_task_subsystem
+    implements: "Orchestrate multi-repo subsystem creation in task directory context"
+  - ref: src/task_utils.py#list_task_subsystems
+    implements: "List subsystems from external repo with dependents"
+  - ref: src/ve.py#list_subsystems
+    implements: "CLI command with task directory detection for subsystem listing"
+  - ref: src/ve.py#_list_task_subsystems
+    implements: "Handler for task-aware subsystem listing"
+  - ref: src/ve.py#discover
+    implements: "CLI command with task directory detection for subsystem discovery"
+  - ref: src/ve.py#_create_task_subsystem
+    implements: "Handler for task-aware subsystem creation"
+  - ref: tests/test_task_subsystem_discover.py
+    implements: "Integration tests for task-aware subsystem discovery"
+  - ref: tests/test_task_subsystem_list.py
+    implements: "Integration tests for task-aware subsystem listing"
+narrative: null
+subsystems:
+- subsystem_id: workflow_artifacts
+  relationship: implements
+created_after: ["external_resolve_all_types", "sync_all_workflows", "task_aware_narrative_cmds"]
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Extend `ve subsystem discover` and `ve subsystem list` commands to support task directory context, following the pattern established by chunk and narrative task-aware commands. When executed in a task directory (containing `.ve-task.yaml`):
+
+- `ve subsystem discover`: Creates the subsystem in the external repository, then creates `external.yaml` references in each project directory with proper causal ordering.
+- `ve subsystem list`: Lists subsystems from the external repository, showing their dependents.
+
+This enables cross-repository subsystem workflows where teams working on multiple repositories can document architectural patterns in a shared external documentation repository while maintaining references in each participating project.
+
+## Success Criteria
+
+1. **Task-aware subsystem discover**: `ve subsystem discover` detects task directory context via `is_task_directory()` and:
+   - Creates subsystem in the external repository via `Subsystems.create_subsystem()`
+   - Creates `external.yaml` in each project's `docs/subsystems/` directory with proper `created_after` ordering
+   - Updates the external subsystem's OVERVIEW.md with dependents list
+   - Outputs created paths for both external subsystem and project references
+
+2. **Task-aware subsystem list**: `ve subsystem list` in task directory context:
+   - Lists subsystems from the external repository
+   - Shows status and dependents for each subsystem
+   - Supports the same output format as task-aware chunk/narrative list
+
+3. **SubsystemFrontmatter enhanced**: `SubsystemFrontmatter` model in `models.py` adds a `dependents` field (similar to `NarrativeFrontmatter`) for tracking which projects reference external subsystems.
+
+4. **Utility functions**: New functions added to `task_utils.py`:
+   - `create_task_subsystem()` - orchestrates cross-repo subsystem creation
+   - `list_task_subsystems()` - lists subsystems with dependents from external repo
+   - `add_dependents_to_subsystem()` - update subsystem OVERVIEW.md frontmatter with dependents
+   - `TaskSubsystemError` - error class for user-friendly messages
+
+5. **Tests pass**: All existing tests continue to pass, and new tests cover:
+   - Task-aware subsystem discover flow
+   - Task-aware subsystem listing
+   - External.yaml creation for subsystems
+   - Error handling for missing repos/configs

--- a/docs/chunks/task_aware_subsystem_cmds/PLAN.md
+++ b/docs/chunks/task_aware_subsystem_cmds/PLAN.md
@@ -1,0 +1,298 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+Follow the established pattern from task-aware narrative commands (`create_task_narrative`, `list_task_narratives` in `task_utils.py` and their CLI integration in `ve.py`). The subsystem implementation mirrors this structure:
+
+1. **Add `dependents` field to `SubsystemFrontmatter`** in `models.py` to track cross-repo references (parallel to `NarrativeFrontmatter.dependents`).
+
+2. **Add task-aware utility functions** to `task_utils.py` following the narrative pattern:
+   - `create_task_subsystem()` - orchestrate cross-repo subsystem creation
+   - `list_task_subsystems()` - list subsystems with dependents from external repo
+   - `add_dependents_to_subsystem()` - update subsystem OVERVIEW.md frontmatter with dependents
+   - `TaskSubsystemError` - error class for user-friendly messages
+
+3. **Extend CLI commands** in `ve.py`:
+   - Modify `discover` to detect task directory and delegate to `_create_task_subsystem()`
+   - Modify `list_subsystems` to detect task directory and delegate to `_list_task_subsystems()`
+
+4. **Test-driven development** per TESTING_PHILOSOPHY.md:
+   - Write failing tests first for task-aware subsystem discover/list
+   - Follow the test patterns from `test_task_narrative_create.py` and `test_task_narrative_list.py`
+
+## Subsystem Considerations
+
+- **docs/subsystems/workflow_artifacts** (REFACTORING): This chunk IMPLEMENTS task-aware
+  subsystem commands, extending the external reference pattern to subsystems.
+  The subsystem documents the pattern for cross-repository workflow artifacts.
+
+Since the subsystem is in REFACTORING status, any code touched should follow the
+established patterns:
+- Use `ExternalArtifactRef` for external references
+- Use utilities from `external_refs.py` for external artifact operations
+- Follow the manager class pattern (`Subsystems`) for artifact operations
+- Include backreference comments linking to this chunk and the subsystem
+
+## Sequence
+
+### Step 1: Add dependents field to SubsystemFrontmatter
+
+Update `SubsystemFrontmatter` in `src/models.py`:
+- Add `dependents: list[ExternalArtifactRef] = []` field
+
+Location: `src/models.py`
+
+### Step 2: Write failing tests for task-aware subsystem discover
+
+Create `tests/test_task_subsystem_discover.py` with tests mirroring `test_task_narrative_create.py`:
+
+```python
+class TestSubsystemDiscoverInTaskDirectory:
+    def test_creates_external_subsystem(self, tmp_path):
+        """Creates subsystem in external repo when in task directory."""
+
+    def test_creates_external_yaml_in_each_project(self, tmp_path):
+        """Creates external.yaml in each project's subsystem directory."""
+
+    def test_populates_dependents_in_external_subsystem(self, tmp_path):
+        """Updates external subsystem OVERVIEW.md with dependents list."""
+
+    def test_reports_all_created_paths(self, tmp_path):
+        """Output includes all created paths."""
+
+class TestSubsystemDiscoverOutsideTaskDirectory:
+    def test_behavior_unchanged(self, tmp_path):
+        """Single-repo behavior unchanged when not in task directory."""
+
+class TestSubsystemDiscoverErrorHandling:
+    def test_error_when_external_repo_inaccessible(self, tmp_path):
+        """Reports clear error when external repo directory missing."""
+
+    def test_error_when_project_inaccessible(self, tmp_path):
+        """Reports clear error when project directory missing."""
+```
+
+Location: `tests/test_task_subsystem_discover.py`
+
+### Step 3: Implement TaskSubsystemError and add_dependents_to_subsystem in task_utils.py
+
+Add to `task_utils.py`:
+
+```python
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Task subsystem error class
+class TaskSubsystemError(Exception):
+    """Error during task subsystem creation with user-friendly message."""
+    pass
+
+
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Add dependents to subsystem
+def add_dependents_to_subsystem(
+    subsystem_path: Path,
+    dependents: list[dict],
+) -> None:
+    """Update subsystem OVERVIEW.md frontmatter to include dependents list.
+
+    Args:
+        subsystem_path: Path to the subsystem directory containing OVERVIEW.md
+        dependents: List of {artifact_type, artifact_id, repo} dicts to add as dependents
+
+    Raises:
+        FileNotFoundError: If OVERVIEW.md doesn't exist in subsystem_path
+    """
+```
+
+Location: `src/task_utils.py`
+
+### Step 4: Implement create_task_subsystem in task_utils.py
+
+Add function `create_task_subsystem()` following the `create_task_narrative()` pattern:
+
+```python
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Orchestrate multi-repo subsystem
+def create_task_subsystem(
+    task_dir: Path,
+    short_name: str,
+) -> dict:
+    """Create subsystem in task directory context.
+
+    Orchestrates multi-repo subsystem creation:
+    1. Creates subsystem in external repo
+    2. Creates external.yaml in each project with causal ordering
+    3. Updates external subsystem's OVERVIEW.md with dependents
+
+    Returns:
+        Dict with keys:
+        - external_subsystem_path: Path to created subsystem in external repo
+        - project_refs: Dict mapping project repo ref to created external.yaml path
+
+    Raises:
+        TaskSubsystemError: If any step fails, with user-friendly message
+    """
+```
+
+Location: `src/task_utils.py`
+
+### Step 5: Integrate task-aware subsystem discover into CLI
+
+Update `discover` command in `ve.py`:
+
+```python
+@subsystem.command()
+@click.argument("shortname")
+@click.option("--project-dir", type=click.Path(exists=True, path_type=pathlib.Path), default=".")
+def discover(shortname, project_dir):
+    """Create a new subsystem."""
+    errors = validate_short_name(shortname)
+    if errors:
+        for error in errors:
+            click.echo(f"Error: {error}", err=True)
+        raise SystemExit(1)
+
+    # Normalize to lowercase
+    shortname = shortname.lower()
+
+    # Check if we're in a task directory (cross-repo mode)
+    if is_task_directory(project_dir):
+        _create_task_subsystem(project_dir, shortname)
+        return
+
+    # Existing single-repo logic...
+```
+
+Add helper function `_create_task_subsystem()` following `_create_task_narrative()` pattern.
+
+Location: `src/ve.py`
+
+### Step 6: Run tests and verify subsystem discover works
+
+Run the test suite to verify:
+- All new tests in `test_task_subsystem_discover.py` pass
+- All existing tests still pass
+
+```bash
+uv run pytest tests/test_task_subsystem_discover.py -v
+uv run pytest tests/ -v
+```
+
+### Step 7: Write failing tests for task-aware subsystem list
+
+Create `tests/test_task_subsystem_list.py` with tests mirroring `test_task_narrative_list.py`:
+
+```python
+class TestSubsystemListInTaskDirectory:
+    def test_lists_subsystems_from_external_repo(self, tmp_path):
+        """Lists subsystems from external repo, not local project."""
+
+    def test_shows_dependents_for_each_subsystem(self, tmp_path):
+        """Displays dependents info for subsystems with cross-repo refs."""
+
+    def test_shows_status(self, tmp_path):
+        """Displays subsystem status."""
+
+class TestSubsystemListOutsideTaskDirectory:
+    def test_behavior_unchanged(self, tmp_path):
+        """Single-repo behavior unchanged when not in task directory."""
+```
+
+Location: `tests/test_task_subsystem_list.py`
+
+### Step 8: Implement list_task_subsystems in task_utils.py
+
+Add function `list_task_subsystems()` following the `list_task_narratives()` pattern:
+
+```python
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Task-aware subsystem listing
+def list_task_subsystems(task_dir: Path) -> list[dict]:
+    """List subsystems from external repo with their dependents.
+
+    Args:
+        task_dir: Path to the task directory containing .ve-task.yaml
+
+    Returns:
+        List of dicts with keys: name, status, dependents
+        Sorted by causal ordering (newest first).
+
+    Raises:
+        TaskSubsystemError: If external repo not accessible
+    """
+```
+
+Location: `src/task_utils.py`
+
+### Step 9: Integrate task-aware subsystem list into CLI
+
+Update `list_subsystems` command in `ve.py`:
+
+```python
+@subsystem.command("list")
+@click.option("--project-dir", type=click.Path(exists=True, path_type=pathlib.Path), default=".")
+def list_subsystems(project_dir):
+    """List all subsystems."""
+    # Check if we're in a task directory (cross-repo mode)
+    if is_task_directory(project_dir):
+        _list_task_subsystems(project_dir)
+        return
+
+    # Existing single-repo logic...
+```
+
+Add helper function `_list_task_subsystems()` following `_list_task_narratives()` pattern.
+
+Location: `src/ve.py`
+
+### Step 10: Run full test suite and verify
+
+Run the complete test suite:
+
+```bash
+uv run pytest tests/ -v
+```
+
+Verify:
+- All task-aware subsystem tests pass
+- All existing tests still pass
+- No regressions in narrative or chunk functionality
+
+## Dependencies
+
+- **consolidate_ext_ref_utils chunk** (completed): Provides the `external_refs.py` module
+  with `is_external_artifact()`, `create_external_yaml()`, `load_external_ref()` that we'll
+  use for subsystem external references.
+
+- **consolidate_ext_refs chunk** (completed): Provides `ExternalArtifactRef` model that
+  supports all artifact types via `artifact_type` field.
+
+- **task_aware_narrative_cmds chunk** (completed): Provides the pattern to follow for
+  task-aware subsystem commands, including `TaskNarrativeError`, `create_task_narrative()`,
+  `list_task_narratives()`, and CLI integration.
+
+## Risks and Open Questions
+
+1. **Subsystem template for dependents**: The subsystem template may not include a `dependents`
+   field. We'll add it only when needed via `add_dependents_to_subsystem()`, similar to
+   how chunks and narratives do it via `add_dependents_to_chunk()` and `add_dependents_to_narrative()`.
+
+2. **Validation during discover**: The current `discover` command validates the shortname
+   and checks for duplicates before creation. When in task directory mode, we need to ensure
+   these validations happen against the external repo, not the task directory itself.
+
+## Deviations
+
+<!--
+POPULATE DURING IMPLEMENTATION, not at planning time.
+
+When reality diverges from the plan, document it here:
+- What changed?
+- Why?
+- What was the impact?
+
+Minor deviations (renamed a function, used a different helper) don't need
+documentation. Significant deviations (changed the approach, skipped a step,
+added steps) do.
+-->

--- a/docs/subsystems/workflow_artifacts/OVERVIEW.md
+++ b/docs/subsystems/workflow_artifacts/OVERVIEW.md
@@ -57,6 +57,8 @@ chunks:
   relationship: implements
 - chunk_id: task_aware_narrative_cmds
   relationship: implements
+- chunk_id: task_aware_subsystem_cmds
+  relationship: implements
 code_references:
 - ref: src/chunks.py#Chunks
   implements: Chunk workflow manager class
@@ -175,6 +177,18 @@ code_references:
 - ref: src/ve.py#_list_task_narratives
   implements: CLI handler for task-aware narrative listing
   compliance: COMPLIANT
+- ref: src/task_utils.py#create_task_subsystem
+  implements: Task-aware subsystem creation with external references
+  compliance: COMPLIANT
+- ref: src/task_utils.py#list_task_subsystems
+  implements: Task-aware subsystem listing from external repo
+  compliance: COMPLIANT
+- ref: src/ve.py#_create_task_subsystem
+  implements: CLI handler for task-aware subsystem creation
+  compliance: COMPLIANT
+- ref: src/ve.py#_list_task_subsystems
+  implements: CLI handler for task-aware subsystem listing
+  compliance: COMPLIANT
 proposed_chunks:
 - prompt: Add ChunkStatus StrEnum and ChunkFrontmatter Pydantic model to models.py.
     Define chunk lifecycle states (FUTURE, IMPLEMENTING, ACTIVE, SUPERSEDED, HISTORICAL)
@@ -230,7 +244,7 @@ proposed_chunks:
     in external repo with dependents, create external.yaml in projects; list from
     external repo showing dependents. Follow the pattern established by chunk task-aware
     commands.'
-  chunk_directory: null
+  chunk_directory: task_aware_subsystem_cmds
 created_after:
 - template_system
 ---
@@ -696,6 +710,13 @@ External chunk references now participate in local causal ordering:
   `artifact_type`, `artifact_id`, `main_content`, `secondary_content` fields. CLI
   auto-detects artifact type from directory path and displays type-appropriate files.
 
+- **task_aware_subsystem_cmds** - Extended `ve subsystem discover` and `ve subsystem list`
+  for task directory context. When in task directory: creates subsystem in external repo
+  with dependents, creates external.yaml in projects with causal ordering; lists subsystems
+  from external repo showing dependents. Added `TaskSubsystemError`,
+  `add_dependents_to_subsystem()`, `create_task_subsystem()`, and `list_task_subsystems()`
+  to `task_utils.py`. Added `dependents` field to `SubsystemFrontmatter`.
+
 ## Consolidation Chunks
 
 ### Pending Consolidation
@@ -755,8 +776,10 @@ External chunk references now participate in local causal ordering:
    - Status: Not yet scheduled
    - Dependencies: #5
 
-10. **Task-aware subsystem commands** - Extend `ve subsystem discover` and
-    `ve subsystem list` for task directory context.
-    - Impact: High
-    - Status: Not yet scheduled
-    - Dependencies: #5
+10. ~~**Task-aware subsystem commands**~~ - **RESOLVED** by chunk task_aware_subsystem_cmds.
+    Extended `ve subsystem discover` and `ve subsystem list` for task directory context.
+    When in task directory: creates subsystem in external repo with dependents, creates
+    external.yaml in projects with causal ordering; lists subsystems from external repo
+    showing dependents. Added `TaskSubsystemError`, `add_dependents_to_subsystem()`,
+    `create_task_subsystem()`, and `list_task_subsystems()` to `task_utils.py`. Added
+    `dependents` field to `SubsystemFrontmatter`.

--- a/src/models.py
+++ b/src/models.py
@@ -460,6 +460,7 @@ class ProposedChunk(BaseModel):
 # Chunk: docs/chunks/subsystem_schemas_and_model - Subsystem frontmatter schema
 # Chunk: docs/chunks/proposed_chunks_frontmatter - Added proposed_chunks field
 # Chunk: docs/chunks/created_after_field - Causal ordering field
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Added dependents field
 class SubsystemFrontmatter(BaseModel):
     """Frontmatter schema for subsystem OVERVIEW.md files.
 
@@ -471,6 +472,7 @@ class SubsystemFrontmatter(BaseModel):
     code_references: list[SymbolicReference] = []
     proposed_chunks: list[ProposedChunk] = []
     created_after: list[str] = []
+    dependents: list[ExternalArtifactRef] = []  # For cross-repo subsystems
 
 
 # Chunk: docs/chunks/proposed_chunks_frontmatter - Narrative status enum

--- a/tests/test_task_subsystem_list.py
+++ b/tests/test_task_subsystem_list.py
@@ -1,0 +1,269 @@
+"""Integration tests for task-aware subsystem listing.
+
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Task-aware subsystem list tests
+"""
+
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from ve import cli
+
+
+def make_ve_initialized_git_repo(path):
+    """Helper to create a VE-initialized git repository with a commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    (path / "docs" / "subsystems").mkdir(parents=True)
+    # Create initial commit so HEAD exists
+    (path / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def setup_task_directory(tmp_path, external_name="ext", project_names=None):
+    """Create a complete task directory setup for testing.
+
+    Returns:
+        tuple: (task_dir, external_path, project_paths)
+    """
+    if project_names is None:
+        project_names = ["proj"]
+
+    task_dir = tmp_path
+
+    # Create external repo
+    external_path = task_dir / external_name
+    make_ve_initialized_git_repo(external_path)
+
+    # Create project repos
+    project_paths = []
+    for name in project_names:
+        project_path = task_dir / name
+        make_ve_initialized_git_repo(project_path)
+        project_paths.append(project_path)
+
+    # Create .ve-task.yaml
+    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
+    config_content = f"""external_artifact_repo: acme/{external_name}
+projects:
+{projects_yaml}
+"""
+    (task_dir / ".ve-task.yaml").write_text(config_content)
+
+    return task_dir, external_path, project_paths
+
+
+def create_subsystem_in_external_repo(
+    external_path, short_name, status="DISCOVERING", dependents=None
+):
+    """Create a subsystem directory with OVERVIEW.md in the external repo.
+
+    Args:
+        external_path: Path to the external repository
+        short_name: e.g., "validation"
+        status: Subsystem status (default "DISCOVERING")
+        dependents: List of {artifact_type, artifact_id, repo} dicts (optional)
+
+    Returns:
+        Path to the created subsystem directory
+    """
+    subsystem_dir = external_path / "docs" / "subsystems" / short_name
+    subsystem_dir.mkdir(parents=True, exist_ok=True)
+
+    dependents_yaml = ""
+    if dependents:
+        dependents_lines = []
+        for dep in dependents:
+            dependents_lines.append(f"  - artifact_type: {dep['artifact_type']}")
+            dependents_lines.append(f"    artifact_id: {dep['artifact_id']}")
+            dependents_lines.append(f"    repo: {dep['repo']}")
+        dependents_yaml = "dependents:\n" + "\n".join(dependents_lines)
+
+    overview_content = f"""---
+status: {status}
+chunks: []
+code_references: []
+proposed_chunks: []
+{dependents_yaml}
+---
+
+# Subsystem: {short_name}
+
+## Intent
+
+Test subsystem for {short_name}.
+
+## Scope
+
+### In Scope
+
+- Test scope items
+
+### Out of Scope
+
+- Nothing
+
+## Invariants
+
+- Test invariant
+
+## Code References
+
+None yet.
+"""
+    (subsystem_dir / "OVERVIEW.md").write_text(overview_content)
+    return subsystem_dir
+
+
+class TestSubsystemListInTaskDirectory:
+    """Tests for ve subsystem list in task directory context."""
+
+    def test_lists_subsystems_from_external_repo(self, tmp_path):
+        """Lists subsystems from external repo when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(tmp_path)
+
+        # Create subsystems in external repo
+        create_subsystem_in_external_repo(external_path, "validation")
+        create_subsystem_in_external_repo(external_path, "template_system")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["subsystem", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "docs/subsystems/validation" in result.output
+        assert "docs/subsystems/template_system" in result.output
+
+    def test_shows_dependents_for_each_subsystem(self, tmp_path):
+        """Displays dependents for each subsystem when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(
+            tmp_path, project_names=["service_a", "service_b"]
+        )
+
+        # Create subsystem with dependents in external repo
+        dependents = [
+            {"artifact_type": "subsystem", "artifact_id": "validation", "repo": "acme/service_a"},
+            {"artifact_type": "subsystem", "artifact_id": "validation", "repo": "acme/service_b"},
+        ]
+        create_subsystem_in_external_repo(
+            external_path, "validation", status="DISCOVERING", dependents=dependents
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["subsystem", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "docs/subsystems/validation" in result.output
+        assert "dependents:" in result.output
+        assert "acme/service_a" in result.output
+        assert "acme/service_b" in result.output
+
+    def test_shows_status(self, tmp_path):
+        """Displays subsystem status when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(tmp_path)
+
+        create_subsystem_in_external_repo(external_path, "validation", status="DISCOVERING")
+        create_subsystem_in_external_repo(external_path, "template_system", status="STABLE")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["subsystem", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "[DISCOVERING]" in result.output
+        assert "[STABLE]" in result.output
+
+    def test_error_when_external_repo_inaccessible(self, tmp_path):
+        """Reports clear error when external repo not accessible."""
+        task_dir = tmp_path
+
+        # Create project but not external repo
+        project_path = task_dir / "proj"
+        make_ve_initialized_git_repo(project_path)
+
+        # Create config referencing missing external repo
+        config_content = """external_artifact_repo: acme/missing_ext
+projects:
+  - acme/proj
+"""
+        (task_dir / ".ve-task.yaml").write_text(config_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["subsystem", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "External" in result.output
+        assert "not found" in result.output
+
+    def test_error_when_no_subsystems_in_external_repo(self, tmp_path):
+        """Reports 'No subsystems found' when external repo has no subsystems."""
+        task_dir, _, _ = setup_task_directory(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["subsystem", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "No subsystems found" in result.output
+
+
+class TestSubsystemListOutsideTaskDirectory:
+    """Tests for ve subsystem list outside task directory context."""
+
+    def test_single_repo_behavior_unchanged(self, tmp_path):
+        """Single-repo behavior unchanged when not in task directory."""
+        # Create a regular VE project (no .ve-task.yaml)
+        project_path = tmp_path / "regular_project"
+        make_ve_initialized_git_repo(project_path)
+
+        # Create a subsystem directly
+        subsystem_dir = project_path / "docs" / "subsystems" / "my_subsystem"
+        subsystem_dir.mkdir(parents=True)
+        overview_content = """---
+status: DISCOVERING
+chunks: []
+code_references: []
+proposed_chunks: []
+---
+
+# Subsystem
+
+Test subsystem.
+"""
+        (subsystem_dir / "OVERVIEW.md").write_text(overview_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["subsystem", "list", "--project-dir", str(project_path)]
+        )
+
+        assert result.exit_code == 0
+        assert "docs/subsystems/my_subsystem [DISCOVERING]" in result.output
+        # Should NOT have dependents line in single-repo mode
+        assert "dependents:" not in result.output


### PR DESCRIPTION
## Summary

Extend `ve subsystem discover` and `ve subsystem list` commands to support task directory context for cross-repository subsystem workflows. When executed in a task directory (containing `.ve-task.yaml`), subsystems are created in the external repository with proper external.yaml references and dependents tracking in each project.

## Test Plan

- ✅ All existing tests continue to pass
- ✅ New integration tests cover task-aware subsystem discover with proper external.yaml creation and dependents population
- ✅ New integration tests cover task-aware subsystem list with status and dependents display
- ✅ Error handling validated for missing repositories and inaccessible configurations

🤖 Generated with Claude Code