### PR TITLE
feat: add task-aware investigation create and list commands

### DIFF
--- a/docs/chunks/task_aware_investigations/GOAL.md
+++ b/docs/chunks/task_aware_investigations/GOAL.md
@@ -1,0 +1,79 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+- src/models.py
+- src/task_utils.py
+- src/ve.py
+- tests/test_task_investigation_create.py
+- tests/test_task_investigation_list.py
+code_references:
+  - ref: src/models.py#InvestigationFrontmatter
+    implements: "Added dependents field for cross-repo investigation tracking"
+  - ref: src/task_utils.py#TaskInvestigationError
+    implements: "Error class for task investigation operations with user-friendly messages"
+  - ref: src/task_utils.py#add_dependents_to_investigation
+    implements: "Helper to update investigation OVERVIEW.md frontmatter with dependents list"
+  - ref: src/task_utils.py#create_task_investigation
+    implements: "Orchestrates multi-repo investigation creation with external.yaml and dependents"
+  - ref: src/task_utils.py#list_task_investigations
+    implements: "Lists investigations from external repo with their dependents"
+  - ref: src/ve.py#create_investigation
+    implements: "CLI command extended with task directory detection"
+  - ref: src/ve.py#_create_task_investigation
+    implements: "Handler for task directory investigation creation"
+  - ref: src/ve.py#list_investigations
+    implements: "CLI command extended with task directory detection"
+  - ref: src/ve.py#_list_task_investigations
+    implements: "Handler for task directory investigation listing"
+  - ref: tests/test_task_investigation_create.py
+    implements: "Integration tests for task-aware investigation creation"
+  - ref: tests/test_task_investigation_list.py
+    implements: "Integration tests for task-aware investigation listing"
+narrative: null
+subsystems:
+- subsystem_id: workflow_artifacts
+  relationship: implements
+created_after: ["external_resolve_all_types", "sync_all_workflows", "task_aware_narrative_cmds"]
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Extend `ve investigation create` and `ve investigation list` commands to support task directory context, following the pattern established by chunk and narrative task-aware commands. When executed in a task directory (containing `.ve-task.yaml`):
+
+- `ve investigation create`: Creates the investigation in the external repository, then creates `external.yaml` references in each project directory with proper causal ordering.
+- `ve investigation list`: Lists investigations from the external repository, showing their dependents.
+
+This enables cross-repository investigation workflows where teams working on multiple repositories can track diagnostic or exploratory work in a shared external documentation repository while maintaining references in each participating project.
+
+## Success Criteria
+
+1. **Task-aware investigation create**: `ve investigation create` detects task directory context via `is_task_directory()` and:
+   - Creates investigation in the external repository via `Investigations.create_investigation()`
+   - Creates `external.yaml` in each project's `docs/investigations/` directory with proper `created_after` ordering
+   - Updates the external investigation's OVERVIEW.md with dependents list
+   - Outputs created paths for both external investigation and project references
+
+2. **Task-aware investigation list**: `ve investigation list` in task directory context:
+   - Lists investigations from the external repository
+   - Shows status and dependents for each investigation
+   - Supports the same output format as task-aware chunk/narrative list
+
+3. **Utility functions**: New functions added to `task_utils.py`:
+   - `create_task_investigation()` - orchestrates cross-repo investigation creation
+   - `list_task_investigations()` - lists investigations with dependents from external repo
+   - `TaskInvestigationError` - error class for user-friendly messages
+
+4. **Model updates**: `InvestigationFrontmatter` in `models.py` updated:
+   - Add `dependents: list[InvestigationDependent]` field to track which projects reference this investigation
+   - `InvestigationDependent` model with `project_path` and `artifact_id` fields (following `NarrativeDependent` pattern)
+
+5. **Tests pass**: All existing tests continue to pass, and new tests cover:
+   - Task-aware investigation creation flow
+   - Task-aware investigation listing
+   - External.yaml creation for investigations
+   - Error handling for missing repos/configs
+

--- a/docs/chunks/task_aware_investigations/PLAN.md
+++ b/docs/chunks/task_aware_investigations/PLAN.md
@@ -1,0 +1,221 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+This chunk extends the investigation commands (`ve investigation create` and `ve investigation list`) to support task directory context, following the exact pattern established by the task-aware narrative commands implemented in chunk `task_aware_narrative_cmds`.
+
+The implementation will:
+1. Add `InvestigationDependent` model and `dependents` field to `InvestigationFrontmatter` (following `NarrativeFrontmatter` pattern)
+2. Add task-aware utility functions to `task_utils.py` (`TaskInvestigationError`, `create_task_investigation()`, `list_task_investigations()`, `add_dependents_to_investigation()`)
+3. Modify CLI commands in `ve.py` to detect task directory context and delegate to task-aware handlers
+4. Create integration tests following the patterns in `test_task_narrative_create.py` and `test_task_narrative_list.py`
+
+The approach maintains DEC-002 compliance (git not assumed for basic operations) and follows the established `external.yaml` pattern for cross-repo references.
+
+## Subsystem Considerations
+
+- **docs/subsystems/workflow_artifacts** (REFACTORING): This chunk IMPLEMENTS the task-aware investigation commands as documented in the subsystem's proposed chunks. The implementation follows the established patterns for external references (`ExternalArtifactRef`), causal ordering (`created_after`), and task directory detection (`is_task_directory()`).
+
+## Sequence
+
+### Step 1: Add InvestigationDependent model and dependents field to InvestigationFrontmatter
+
+Update `src/models.py` to add the `dependents` field to `InvestigationFrontmatter`, following the pattern from `NarrativeFrontmatter`:
+
+```python
+class InvestigationFrontmatter(BaseModel):
+    """Frontmatter schema for investigation OVERVIEW.md files."""
+
+    status: InvestigationStatus
+    trigger: str | None = None
+    proposed_chunks: list[ProposedChunk] = []
+    created_after: list[str] = []
+    dependents: list[ExternalArtifactRef] = []  # For cross-repo investigations
+```
+
+Location: `src/models.py`
+
+### Step 2: Add TaskInvestigationError class to task_utils.py
+
+Add a new error class for task investigation operations, following the pattern from `TaskNarrativeError`:
+
+```python
+class TaskInvestigationError(Exception):
+    """Error during task investigation creation with user-friendly message."""
+    pass
+```
+
+Location: `src/task_utils.py`
+
+### Step 3: Add add_dependents_to_investigation() function
+
+Add a helper function to update investigation OVERVIEW.md frontmatter with dependents, following the pattern from `add_dependents_to_narrative()`:
+
+```python
+def add_dependents_to_investigation(
+    investigation_path: Path,
+    dependents: list[dict],
+) -> None:
+    """Update investigation OVERVIEW.md frontmatter to include dependents list."""
+```
+
+Location: `src/task_utils.py`
+
+### Step 4: Write failing tests for create_task_investigation()
+
+Create `tests/test_task_investigation_create.py` with tests that verify:
+- Creates investigation in external repo when in task directory
+- Creates `external.yaml` in each project's `docs/investigations/` directory
+- Populates dependents in external investigation's OVERVIEW.md
+- Resolves pinned SHA from external repo
+- Reports all created paths
+- Handles error when external repo inaccessible
+- Handles error when project inaccessible
+- Single-repo behavior unchanged when not in task directory
+
+Follow the test patterns from `tests/test_task_narrative_create.py`.
+
+Location: `tests/test_task_investigation_create.py`
+
+### Step 5: Implement create_task_investigation() function
+
+Implement the orchestration function for multi-repo investigation creation, following the pattern from `create_task_narrative()`:
+
+```python
+def create_task_investigation(
+    task_dir: Path,
+    short_name: str,
+) -> dict:
+    """Create investigation in task directory context.
+
+    Orchestrates multi-repo investigation creation:
+    1. Creates investigation in external repo
+    2. Creates external.yaml in each project with causal ordering
+    3. Updates external investigation's OVERVIEW.md with dependents
+
+    Returns:
+        Dict with keys:
+        - external_investigation_path: Path to created investigation in external repo
+        - project_refs: Dict mapping project repo ref to created external.yaml path
+    """
+```
+
+Location: `src/task_utils.py`
+
+### Step 6: Modify create_investigation CLI command for task directory detection
+
+Update the `create_investigation` command in `ve.py` to detect task directory context and delegate to a task-aware handler:
+
+```python
+@investigation.command("create")
+@click.argument("short_name")
+@click.option("--project-dir", type=click.Path(exists=True, path_type=pathlib.Path), default=".")
+def create_investigation(short_name, project_dir):
+    """Create a new investigation."""
+    # ... validation ...
+
+    # Check if we're in a task directory (cross-repo mode)
+    if is_task_directory(project_dir):
+        _create_task_investigation(project_dir, short_name)
+        return
+
+    # Single-repo mode (existing behavior)
+    # ...
+```
+
+Add the helper function `_create_task_investigation()` following the pattern from `_create_task_narrative()`.
+
+Location: `src/ve.py`
+
+### Step 7: Run tests for create functionality
+
+Run `pytest tests/test_task_investigation_create.py` to verify the create functionality works correctly.
+
+### Step 8: Write failing tests for list_task_investigations()
+
+Create `tests/test_task_investigation_list.py` with tests that verify:
+- Lists investigations from external repo when in task directory
+- Shows dependents for each investigation
+- Shows status
+- Handles error when external repo inaccessible
+- Handles "No investigations found" case
+- Single-repo behavior unchanged when not in task directory
+
+Follow the test patterns from `tests/test_task_narrative_list.py`.
+
+Location: `tests/test_task_investigation_list.py`
+
+### Step 9: Implement list_task_investigations() function
+
+Implement the function to list investigations from external repo with their dependents, following the pattern from `list_task_narratives()`:
+
+```python
+def list_task_investigations(task_dir: Path) -> list[dict]:
+    """List investigations from external repo with their dependents.
+
+    Returns:
+        List of dicts with keys: name, status, dependents
+        Sorted by investigation name descending.
+    """
+```
+
+Location: `src/task_utils.py`
+
+### Step 10: Modify list_investigations CLI command for task directory detection
+
+Update the `list_investigations` command in `ve.py` to detect task directory context and delegate to a task-aware handler:
+
+```python
+@investigation.command("list")
+@click.option("--state", type=str, default=None, help="Filter by investigation state")
+@click.option("--project-dir", type=click.Path(exists=True, path_type=pathlib.Path), default=".")
+def list_investigations(state, project_dir):
+    """List all investigations."""
+    # Check if we're in a task directory (cross-repo mode)
+    if is_task_directory(project_dir):
+        _list_task_investigations(project_dir)
+        return
+
+    # Single-repo mode (existing behavior)
+    # ...
+```
+
+Add the helper function `_list_task_investigations()` following the pattern from `_list_task_narratives()`.
+
+Location: `src/ve.py`
+
+### Step 11: Run all tests
+
+Run `pytest tests/` to verify all tests pass, including the new investigation tests and existing tests.
+
+### Step 12: Update GOAL.md code_paths
+
+Update the chunk's GOAL.md frontmatter with the files touched during implementation:
+- `src/models.py`
+- `src/task_utils.py`
+- `src/ve.py`
+- `tests/test_task_investigation_create.py`
+- `tests/test_task_investigation_list.py`
+
+Location: `docs/chunks/task_aware_investigations/GOAL.md`
+
+## Dependencies
+
+- **chunk consolidate_ext_ref_utils** (COMPLETE): Provides `is_external_artifact()`, `load_external_ref()`, `create_external_yaml()` in `src/external_refs.py`
+- **chunk task_aware_narrative_cmds** (COMPLETE): Establishes the pattern for task-aware workflow artifact commands
+
+## Risks and Open Questions
+
+- **None identified**: The implementation closely follows the established pattern from narratives, minimizing risk. The `external_refs.py` utilities already support all artifact types including `ArtifactType.INVESTIGATION`.
+
+## Deviations
+
+<!--
+POPULATE DURING IMPLEMENTATION, not at planning time.
+-->

--- a/docs/subsystems/workflow_artifacts/OVERVIEW.md
+++ b/docs/subsystems/workflow_artifacts/OVERVIEW.md
@@ -57,6 +57,8 @@ chunks:
   relationship: implements
 - chunk_id: task_aware_narrative_cmds
   relationship: implements
+- chunk_id: task_aware_investigations
+  relationship: implements
 - chunk_id: task_aware_subsystem_cmds
   relationship: implements
 code_references:
@@ -177,6 +179,18 @@ code_references:
 - ref: src/ve.py#_list_task_narratives
   implements: CLI handler for task-aware narrative listing
   compliance: COMPLIANT
+- ref: src/task_utils.py#create_task_investigation
+  implements: Task-aware investigation creation with external references
+  compliance: COMPLIANT
+- ref: src/task_utils.py#list_task_investigations
+  implements: Task-aware investigation listing from external repo
+  compliance: COMPLIANT
+- ref: src/ve.py#_create_task_investigation
+  implements: CLI handler for task-aware investigation creation
+  compliance: COMPLIANT
+- ref: src/ve.py#_list_task_investigations
+  implements: CLI handler for task-aware investigation listing
+  compliance: COMPLIANT
 - ref: src/task_utils.py#create_task_subsystem
   implements: Task-aware subsystem creation with external references
   compliance: COMPLIANT
@@ -221,7 +235,7 @@ proposed_chunks:
 - prompt: 'Extend ve sync to all workflow types: Update ve sync to find and update
     external.yaml files in docs/narratives/, docs/investigations/, and docs/subsystems/
     directories, not just docs/chunks/. Use the consolidated external reference utilities.'
-  chunk_directory: null
+  chunk_directory: sync_all_workflows
 - prompt: 'Extend ve external resolve to all workflow types: Update ve external resolve
     to work with any workflow artifact type. Detect type from directory path (chunks/,
     narratives/, investigations/, subsystems/). Display appropriate files (GOAL.md+PLAN.md
@@ -238,7 +252,7 @@ proposed_chunks:
     investigation in external repo with dependents, create external.yaml in projects;
     list from external repo showing dependents. Follow the pattern established by
     chunk task-aware commands.'
-  chunk_directory: null
+  chunk_directory: task_aware_investigations
 - prompt: 'Task-aware subsystem commands: Extend ve subsystem discover and ve subsystem
     list to detect task directory context. When in task directory: create subsystem
     in external repo with dependents, create external.yaml in projects; list from
@@ -689,6 +703,13 @@ External chunk references now participate in local causal ordering:
   to `task_utils.py`. Added `dependents` field to `NarrativeFrontmatter`. Renamed
   `external_chunk_repo` to `external_artifact_repo` in `TaskConfig` for generality.
 
+- **task_aware_investigations** - Extended `ve investigation create` and `ve investigation
+  list` with task directory context detection. When in task directory: creates investigation
+  in external repo with dependents, creates `external.yaml` in projects with causal ordering;
+  lists investigations from external repo showing dependents. Added `TaskInvestigationError`,
+  `add_dependents_to_investigation()`, `create_task_investigation()`, `list_task_investigations()`
+  to `task_utils.py`. Added `dependents` field to `InvestigationFrontmatter`.
+
 - **consolidate_ext_refs** - Created `ExternalArtifactRef` model as a type-agnostic
   replacement for `ExternalChunkRef`. Added `artifact_type` and `artifact_id` fields.
   Moved `ArtifactType` enum from `artifact_ordering.py` to `models.py` to enable import.
@@ -770,11 +791,13 @@ External chunk references now participate in local causal ordering:
    `NarrativeFrontmatter`. Renamed `external_chunk_repo` to `external_artifact_repo`
    in `TaskConfig` for generality.
 
-9. **Task-aware investigation commands** - Extend `ve investigation create` and
-   `ve investigation list` for task directory context.
-   - Impact: High
-   - Status: Not yet scheduled
-   - Dependencies: #5
+9. ~~**Task-aware investigation commands**~~ - **RESOLVED** by chunk task_aware_investigations.
+   Extended `ve investigation create` and `ve investigation list` for task directory context.
+   When in task directory: creates investigation in external repo with dependents, creates
+   external.yaml in projects; lists from external repo showing dependents. Added
+   `TaskInvestigationError`, `add_dependents_to_investigation()`, `create_task_investigation()`,
+   and `list_task_investigations()` to `task_utils.py`. Added `dependents` field to
+   `InvestigationFrontmatter`.
 
 10. ~~**Task-aware subsystem commands**~~ - **RESOLVED** by chunk task_aware_subsystem_cmds.
     Extended `ve subsystem discover` and `ve subsystem list` for task directory context.

--- a/docs/trunk/TESTING_PHILOSOPHY.md
+++ b/docs/trunk/TESTING_PHILOSOPHY.md
@@ -179,6 +179,52 @@ tests/
 
 Naming convention: `test_<module>.py` for unit tests, `test_<command>.py` for CLI tests.
 
+## Test Helper Reuse
+
+### Check Before You Copy
+
+Before writing a new test helper function, check `tests/conftest.py` for existing helpers that do what you need. Common patterns like creating git repositories, setting up directory structures, or configuring test environments often already exist.
+
+**Before writing any helper that:**
+- Creates or initializes directories
+- Sets up git repositories
+- Creates configuration files
+- Builds complex test fixtures
+
+**First search conftest.py** for similar functionality. If a helper exists but doesn't quite fit, prefer extending the existing helper over duplicating it.
+
+### When to Extract to conftest.py
+
+Extract a helper to `conftest.py` when:
+
+1. **You need it in a second file.** The moment you're about to copy a helper from one test file to another, stop. Move it to conftest.py instead.
+
+2. **The helper sets up common infrastructure.** Helpers that create git repos, initialize VE projects, or set up task directories are inherently reusable.
+
+3. **The helper is 10+ lines.** Large helpers that get copied become maintenance burdens—a bug fix must be applied everywhere.
+
+### Anti-Pattern: Copy-Paste Helpers
+
+When adding a new test file, resist the temptation to copy helper functions from a similar test file. This pattern caused 10 test files to each contain their own 60-line copy of the same helpers.
+
+**Wrong approach:**
+```python
+# test_task_foo.py - copying from test_task_bar.py
+def make_ve_initialized_git_repo(path):
+    # 30 lines of setup...
+
+def setup_task_directory(tmp_path):
+    # 30 lines of setup...
+```
+
+**Right approach:**
+```python
+# test_task_foo.py - importing from conftest
+from conftest import make_ve_initialized_git_repo, setup_task_directory
+```
+
+If the helper doesn't exist in conftest.py yet, add it there first, then import it.
+
 ## CI Requirements
 
 All tests must pass before code is merged:

--- a/src/models.py
+++ b/src/models.py
@@ -277,45 +277,6 @@ class TaskConfig(BaseModel):
         return v
 
 
-# Chunk: docs/chunks/cross_repo_schemas - External chunk reference
-# Chunk: docs/chunks/external_chunk_causal - Local causal ordering for external refs
-class ExternalChunkRef(BaseModel):
-    """Reference to a chunk in another repository.
-
-    Used for both:
-    - external.yaml files in participating repos (with track/pinned)
-    - dependents list in external chunk GOAL.md (without track/pinned)
-    """
-
-    repo: str  # GitHub-style org/repo format
-    chunk: str  # Chunk directory name
-    track: str | None = None  # Branch to follow (optional)
-    pinned: str | None = None  # 40-char SHA (optional)
-    created_after: list[str] = []  # Local causal ordering (for external.yaml)
-
-    @field_validator("repo")
-    @classmethod
-    def validate_repo(cls, v: str) -> str:
-        """Validate repo is in org/repo format."""
-        return _require_valid_repo_ref(v, "repo")
-
-    @field_validator("chunk")
-    @classmethod
-    def validate_chunk(cls, v: str) -> str:
-        """Validate chunk is a valid directory name."""
-        return _require_valid_dir_name(v, "chunk")
-
-    @field_validator("pinned")
-    @classmethod
-    def validate_pinned(cls, v: str | None) -> str | None:
-        """Validate pinned is a 40-character hex SHA if provided."""
-        if v is None:
-            return v
-        if not SHA_PATTERN.match(v):
-            raise ValueError("pinned must be a 40-character lowercase hex SHA")
-        return v
-
-
 # Chunk: docs/chunks/consolidate_ext_refs - Generic external artifact reference
 class ExternalArtifactRef(BaseModel):
     """Reference to a workflow artifact in another repository.

--- a/src/models.py
+++ b/src/models.py
@@ -511,6 +511,7 @@ class NarrativeFrontmatter(BaseModel):
 # Chunk: docs/chunks/investigation_commands - Investigation frontmatter schema
 # Chunk: docs/chunks/proposed_chunks_frontmatter - Updated to use ProposedChunk
 # Chunk: docs/chunks/created_after_field - Causal ordering field
+# Chunk: docs/chunks/task_aware_investigations - Added dependents field
 class InvestigationFrontmatter(BaseModel):
     """Frontmatter schema for investigation OVERVIEW.md files.
 
@@ -521,6 +522,7 @@ class InvestigationFrontmatter(BaseModel):
     trigger: str | None = None
     proposed_chunks: list[ProposedChunk] = []
     created_after: list[str] = []
+    dependents: list[ExternalArtifactRef] = []  # For cross-repo investigations
 
 
 # Chunk: docs/chunks/chunk_frontmatter_model - Chunk frontmatter schema

--- a/src/task_utils.py
+++ b/src/task_utils.py
@@ -642,7 +642,6 @@ def list_task_narratives(task_dir: Path) -> list[dict]:
         TaskNarrativeError: If external repo not accessible
     """
     from narratives import Narratives
-    from artifact_ordering import ArtifactIndex
 
     # Load task config
     try:

--- a/src/task_utils.py
+++ b/src/task_utils.py
@@ -444,6 +444,20 @@ class TaskNarrativeError(Exception):
     pass
 
 
+# Chunk: docs/chunks/task_aware_investigations - Task investigation error class
+class TaskInvestigationError(Exception):
+    """Error during task investigation creation with user-friendly message."""
+
+    pass
+
+
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Task subsystem error class
+class TaskSubsystemError(Exception):
+    """Error during task subsystem creation with user-friendly message."""
+
+    pass
+
+
 # Chunk: docs/chunks/task_aware_narrative_cmds - Add dependents to narrative
 def add_dependents_to_narrative(
     narrative_path: Path,
@@ -461,6 +475,48 @@ def add_dependents_to_narrative(
     overview_path = narrative_path / "OVERVIEW.md"
     if not overview_path.exists():
         raise FileNotFoundError(f"OVERVIEW.md not found in {narrative_path}")
+
+    update_frontmatter_field(overview_path, "dependents", dependents)
+
+
+# Chunk: docs/chunks/task_aware_investigations - Add dependents to investigation
+def add_dependents_to_investigation(
+    investigation_path: Path,
+    dependents: list[dict],
+) -> None:
+    """Update investigation OVERVIEW.md frontmatter to include dependents list.
+
+    Args:
+        investigation_path: Path to the investigation directory containing OVERVIEW.md
+        dependents: List of {artifact_type, artifact_id, repo} dicts to add as dependents
+
+    Raises:
+        FileNotFoundError: If OVERVIEW.md doesn't exist in investigation_path
+    """
+    overview_path = investigation_path / "OVERVIEW.md"
+    if not overview_path.exists():
+        raise FileNotFoundError(f"OVERVIEW.md not found in {investigation_path}")
+
+    update_frontmatter_field(overview_path, "dependents", dependents)
+
+
+# Chunk: docs/chunks/task_aware_subsystem_cmds - Add dependents to subsystem
+def add_dependents_to_subsystem(
+    subsystem_path: Path,
+    dependents: list[dict],
+) -> None:
+    """Update subsystem OVERVIEW.md frontmatter to include dependents list.
+
+    Args:
+        subsystem_path: Path to the subsystem directory containing OVERVIEW.md
+        dependents: List of {artifact_type, artifact_id, repo} dicts to add as dependents
+
+    Raises:
+        FileNotFoundError: If OVERVIEW.md doesn't exist in subsystem_path
+    """
+    overview_path = subsystem_path / "OVERVIEW.md"
+    if not overview_path.exists():
+        raise FileNotFoundError(f"OVERVIEW.md not found in {subsystem_path}")
 
     update_frontmatter_field(overview_path, "dependents", dependents)
 
@@ -630,32 +686,168 @@ def list_task_narratives(task_dir: Path) -> list[dict]:
     return results
 
 
-# Chunk: docs/chunks/task_aware_subsystem_cmds - Task subsystem error class
-class TaskSubsystemError(Exception):
-    """Error during task subsystem creation with user-friendly message."""
+# Chunk: docs/chunks/task_aware_investigations - Orchestrate multi-repo investigation
+def create_task_investigation(
+    task_dir: Path,
+    short_name: str,
+) -> dict:
+    """Create investigation in task directory context.
 
-    pass
-
-
-# Chunk: docs/chunks/task_aware_subsystem_cmds - Add dependents to subsystem
-def add_dependents_to_subsystem(
-    subsystem_path: Path,
-    dependents: list[dict],
-) -> None:
-    """Update subsystem OVERVIEW.md frontmatter to include dependents list.
+    Orchestrates multi-repo investigation creation:
+    1. Creates investigation in external repo
+    2. Creates external.yaml in each project with causal ordering
+    3. Updates external investigation's OVERVIEW.md with dependents
 
     Args:
-        subsystem_path: Path to the subsystem directory containing OVERVIEW.md
-        dependents: List of {artifact_type, artifact_id, repo} dicts to add as dependents
+        task_dir: Path to the task directory containing .ve-task.yaml
+        short_name: Short name for the investigation
+
+    Returns:
+        Dict with keys:
+        - external_investigation_path: Path to created investigation in external repo
+        - project_refs: Dict mapping project repo ref to created external.yaml path
 
     Raises:
-        FileNotFoundError: If OVERVIEW.md doesn't exist in subsystem_path
+        TaskInvestigationError: If any step fails, with user-friendly message
     """
-    overview_path = subsystem_path / "OVERVIEW.md"
-    if not overview_path.exists():
-        raise FileNotFoundError(f"OVERVIEW.md not found in {subsystem_path}")
+    from investigations import Investigations
 
-    update_frontmatter_field(overview_path, "dependents", dependents)
+    # 1. Load task config
+    try:
+        config = load_task_config(task_dir)
+    except FileNotFoundError:
+        raise TaskInvestigationError(
+            f"Task configuration not found. Expected .ve-task.yaml in {task_dir}"
+        )
+
+    # 2. Resolve external repo path
+    try:
+        external_repo_path = resolve_repo_directory(task_dir, config.external_artifact_repo)
+    except FileNotFoundError:
+        raise TaskInvestigationError(
+            f"External investigation repository '{config.external_artifact_repo}' not found or not accessible"
+        )
+
+    # 3. Get current SHA from external repo
+    try:
+        pinned_sha = get_current_sha(external_repo_path)
+    except ValueError as e:
+        raise TaskInvestigationError(
+            f"Failed to resolve HEAD SHA in external repository '{config.external_artifact_repo}': {e}"
+        )
+
+    # 4. Create investigation in external repo
+    investigations = Investigations(external_repo_path)
+    external_investigation_path = investigations.create_investigation(short_name)
+    external_artifact_id = external_investigation_path.name
+
+    # 5-6. For each project: create external.yaml with causal ordering, build dependents
+    dependents = []
+    project_refs = {}
+
+    for project_ref in config.projects:
+        # Resolve project path
+        try:
+            project_path = resolve_repo_directory(task_dir, project_ref)
+        except FileNotFoundError:
+            raise TaskInvestigationError(
+                f"Project directory '{project_ref}' not found or not accessible"
+            )
+
+        # Get current tips for this project's causal ordering
+        try:
+            index = ArtifactIndex(project_path)
+            tips = index.find_tips(ArtifactType.INVESTIGATION)
+        except Exception:
+            tips = []
+
+        # Create external.yaml with created_after
+        external_yaml_path = create_external_yaml(
+            project_path=project_path,
+            short_name=short_name,
+            external_repo_ref=config.external_artifact_repo,
+            external_artifact_id=external_artifact_id,
+            pinned_sha=pinned_sha,
+            created_after=tips,
+            artifact_type=ArtifactType.INVESTIGATION,
+        )
+
+        # Build dependent entry using ExternalArtifactRef format
+        dependents.append({
+            "artifact_type": ArtifactType.INVESTIGATION.value,
+            "artifact_id": short_name,
+            "repo": project_ref,
+        })
+
+        # Track created path
+        project_refs[project_ref] = external_yaml_path
+
+    # 7. Update external investigation's OVERVIEW.md with dependents
+    add_dependents_to_investigation(external_investigation_path, dependents)
+
+    # 8. Return results
+    return {
+        "external_investigation_path": external_investigation_path,
+        "project_refs": project_refs,
+    }
+
+
+# Chunk: docs/chunks/task_aware_investigations - Task-aware investigation listing
+def list_task_investigations(task_dir: Path) -> list[dict]:
+    """List investigations from external repo with their dependents.
+
+    Args:
+        task_dir: Path to the task directory containing .ve-task.yaml
+
+    Returns:
+        List of dicts with keys: name, status, dependents
+        Sorted by investigation name descending.
+
+    Raises:
+        TaskInvestigationError: If external repo not accessible
+    """
+    from investigations import Investigations
+
+    # Load task config
+    try:
+        config = load_task_config(task_dir)
+    except FileNotFoundError:
+        raise TaskInvestigationError(
+            f"Task configuration not found. Expected .ve-task.yaml in {task_dir}"
+        )
+
+    # Resolve external repo path
+    try:
+        external_repo_path = resolve_repo_directory(task_dir, config.external_artifact_repo)
+    except FileNotFoundError:
+        raise TaskInvestigationError(
+            f"External investigation repository '{config.external_artifact_repo}' not found or not accessible"
+        )
+
+    # List investigations from external repo
+    investigations = Investigations(external_repo_path)
+    artifact_index = ArtifactIndex(external_repo_path)
+
+    # Get investigations in causal order (oldest first from index) and reverse for newest first
+    ordered = artifact_index.get_ordered(ArtifactType.INVESTIGATION)
+    investigation_list = list(reversed(ordered))
+
+    results = []
+    for investigation_name in investigation_list:
+        frontmatter = investigations.parse_investigation_frontmatter(investigation_name)
+        status = frontmatter.status.value if frontmatter else "UNKNOWN"
+        # Convert ExternalArtifactRef objects to dicts for API compatibility
+        dependents = [
+            {"artifact_type": d.artifact_type.value, "artifact_id": d.artifact_id, "repo": d.repo}
+            for d in frontmatter.dependents
+        ] if frontmatter else []
+        results.append({
+            "name": investigation_name,
+            "status": status,
+            "dependents": dependents,
+        })
+
+    return results
 
 
 # Chunk: docs/chunks/task_aware_subsystem_cmds - Orchestrate multi-repo subsystem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for vibe-engineer tests."""
 
 import pathlib
+import subprocess
 import sys
 import tempfile
 
@@ -26,3 +27,77 @@ def temp_project():
 def runner():
     """Create a Click test runner."""
     return CliRunner()
+
+
+def make_ve_initialized_git_repo(path):
+    """Helper to create a VE-initialized git repository with a commit.
+
+    Creates a git repo with docs/{chunks,narratives,investigations,subsystems}
+    directories and an initial commit so HEAD exists.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    # Create all workflow artifact directories
+    (path / "docs" / "chunks").mkdir(parents=True)
+    (path / "docs" / "narratives").mkdir(parents=True)
+    (path / "docs" / "investigations").mkdir(parents=True)
+    (path / "docs" / "subsystems").mkdir(parents=True)
+    # Create initial commit so HEAD exists
+    (path / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def setup_task_directory(tmp_path, external_name="ext", project_names=None):
+    """Create a complete task directory setup for testing.
+
+    Args:
+        tmp_path: Base temporary directory
+        external_name: Name for the external repo directory
+        project_names: List of project directory names (default: ["proj"])
+
+    Returns:
+        tuple: (task_dir, external_path, project_paths)
+    """
+    if project_names is None:
+        project_names = ["proj"]
+
+    task_dir = tmp_path
+
+    # Create external repo
+    external_path = task_dir / external_name
+    make_ve_initialized_git_repo(external_path)
+
+    # Create project repos
+    project_paths = []
+    for name in project_names:
+        project_path = task_dir / name
+        make_ve_initialized_git_repo(project_path)
+        project_paths.append(project_path)
+
+    # Create .ve-task.yaml
+    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
+    config_content = f"""external_artifact_repo: acme/{external_name}
+projects:
+{projects_yaml}
+"""
+    (task_dir / ".ve-task.yaml").write_text(config_content)
+
+    return task_dir, external_path, project_paths

--- a/tests/test_task_chunk_create.py
+++ b/tests/test_task_chunk_create.py
@@ -7,67 +7,7 @@ from click.testing import CliRunner
 
 from ve import cli
 from task_utils import load_external_ref, load_task_config
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "chunks").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 # Chunk: docs/chunks/remove_sequence_prefix - Updated for short_name only format

--- a/tests/test_task_chunk_list.py
+++ b/tests/test_task_chunk_list.py
@@ -6,67 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from ve import cli
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "chunks").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 def create_chunk_in_external_repo(

--- a/tests/test_task_init.py
+++ b/tests/test_task_init.py
@@ -6,25 +6,7 @@ import pytest
 
 from task_init import TaskInit, TaskInitResult
 from task_utils import load_task_config
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "chunks").mkdir(parents=True)
+from conftest import make_ve_initialized_git_repo
 
 
 class TestTaskInitValidate:

--- a/tests/test_task_init_cli.py
+++ b/tests/test_task_init_cli.py
@@ -4,25 +4,7 @@ import subprocess
 import tempfile
 
 from ve import cli
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "chunks").mkdir(parents=True)
+from conftest import make_ve_initialized_git_repo
 
 
 class TestTaskInitCommand:

--- a/tests/test_task_investigation_create.py
+++ b/tests/test_task_investigation_create.py
@@ -1,0 +1,287 @@
+"""Integration tests for task-aware investigation creation.
+
+# Chunk: docs/chunks/task_aware_investigations - Task-aware investigation create tests
+"""
+
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from ve import cli
+from task_utils import load_external_ref
+
+
+def make_ve_initialized_git_repo(path):
+    """Helper to create a VE-initialized git repository with a commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    (path / "docs" / "investigations").mkdir(parents=True)
+    # Create initial commit so HEAD exists
+    (path / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def setup_task_directory(tmp_path, external_name="ext", project_names=None):
+    """Create a complete task directory setup for testing.
+
+    Returns:
+        tuple: (task_dir, external_path, project_paths)
+    """
+    if project_names is None:
+        project_names = ["proj"]
+
+    task_dir = tmp_path
+
+    # Create external repo
+    external_path = task_dir / external_name
+    make_ve_initialized_git_repo(external_path)
+
+    # Create project repos
+    project_paths = []
+    for name in project_names:
+        project_path = task_dir / name
+        make_ve_initialized_git_repo(project_path)
+        project_paths.append(project_path)
+
+    # Create .ve-task.yaml
+    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
+    config_content = f"""external_artifact_repo: acme/{external_name}
+projects:
+{projects_yaml}
+"""
+    (task_dir / ".ve-task.yaml").write_text(config_content)
+
+    return task_dir, external_path, project_paths
+
+
+class TestInvestigationCreateInTaskDirectory:
+    """Tests for ve investigation create in task directory context."""
+
+    def test_creates_external_investigation(self, tmp_path):
+        """Creates investigation in external repo when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "Created investigation in external repo" in result.output
+
+        # Verify investigation was created in external repo
+        investigation_dir = external_path / "docs" / "investigations" / "memory_leak"
+        assert investigation_dir.exists()
+        assert (investigation_dir / "OVERVIEW.md").exists()
+
+    def test_creates_external_yaml_in_each_project(self, tmp_path):
+        """Creates external.yaml in each project's investigation directory."""
+        task_dir, _, project_paths = setup_task_directory(
+            tmp_path, project_names=["proj1", "proj2"]
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+
+        # Verify external.yaml in each project
+        for project_path in project_paths:
+            investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+            assert investigation_dir.exists()
+            external_yaml = investigation_dir / "external.yaml"
+            assert external_yaml.exists()
+
+            # Verify content
+            ref = load_external_ref(investigation_dir)
+            assert ref.repo == "acme/ext"
+            assert ref.artifact_id == "memory_leak"
+            assert ref.track == "main"
+            assert len(ref.pinned) == 40  # SHA length
+
+    def test_populates_dependents_in_external_investigation(self, tmp_path):
+        """Updates external investigation OVERVIEW.md with dependents list."""
+        task_dir, external_path, _ = setup_task_directory(
+            tmp_path, project_names=["proj1", "proj2"]
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+
+        # Verify dependents in external investigation OVERVIEW.md
+        overview_path = external_path / "docs" / "investigations" / "memory_leak" / "OVERVIEW.md"
+        content = overview_path.read_text()
+
+        assert "dependents:" in content
+        assert "acme/proj1" in content
+        assert "acme/proj2" in content
+        assert "memory_leak" in content
+
+    def test_resolves_pinned_sha_from_external_repo(self, tmp_path):
+        """Pinned SHA matches HEAD of external repo at creation time."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+
+        # Get expected SHA
+        sha_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=external_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        expected_sha = sha_result.stdout.strip()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+
+        # Verify pinned SHA
+        investigation_dir = project_paths[0] / "docs" / "investigations" / "memory_leak"
+        ref = load_external_ref(investigation_dir)
+        assert ref.pinned == expected_sha
+
+    def test_reports_all_created_paths(self, tmp_path):
+        """Output includes all created paths."""
+        task_dir, _, _ = setup_task_directory(
+            tmp_path, project_names=["proj1", "proj2"]
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "Created investigation in external repo:" in result.output
+        assert "Created reference in acme/proj1:" in result.output
+        assert "Created reference in acme/proj2:" in result.output
+
+
+class TestInvestigationCreateOutsideTaskDirectory:
+    """Tests for ve investigation create outside task directory context."""
+
+    def test_behavior_unchanged(self, tmp_path):
+        """Single-repo behavior unchanged when not in task directory."""
+        # Create a regular VE project (no .ve-task.yaml)
+        project_path = tmp_path / "regular_project"
+        make_ve_initialized_git_repo(project_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(project_path)]
+        )
+
+        assert result.exit_code == 0
+        assert "Created docs/investigations/memory_leak" in result.output
+
+        # Verify regular investigation was created (with OVERVIEW.md, not external.yaml)
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        assert (investigation_dir / "OVERVIEW.md").exists()
+        assert not (investigation_dir / "external.yaml").exists()
+
+
+class TestInvestigationCreateErrorHandling:
+    """Tests for error handling in task-aware investigation creation."""
+
+    def test_error_when_external_repo_inaccessible(self, tmp_path):
+        """Reports clear error when external repo directory missing."""
+        task_dir = tmp_path
+
+        # Create project but not external repo
+        project_path = task_dir / "proj"
+        make_ve_initialized_git_repo(project_path)
+
+        # Create config referencing missing external repo
+        config_content = """external_artifact_repo: acme/missing_ext
+projects:
+  - acme/proj
+"""
+        (task_dir / ".ve-task.yaml").write_text(config_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "External" in result.output
+        assert "not found" in result.output
+
+    def test_error_when_project_inaccessible(self, tmp_path):
+        """Reports clear error when project directory missing."""
+        task_dir = tmp_path
+
+        # Create external repo but not project
+        external_path = task_dir / "ext"
+        make_ve_initialized_git_repo(external_path)
+
+        # Create config referencing missing project
+        config_content = """external_artifact_repo: acme/ext
+projects:
+  - acme/missing_proj
+"""
+        (task_dir / ".ve-task.yaml").write_text(config_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "Project directory" in result.output
+        assert "not found" in result.output
+
+    def test_error_when_external_repo_not_git(self, tmp_path):
+        """Reports clear error when external repo is not a git repository."""
+        task_dir = tmp_path
+
+        # Create external dir (not a git repo)
+        external_path = task_dir / "ext"
+        external_path.mkdir()
+        (external_path / "docs" / "investigations").mkdir(parents=True)
+
+        # Create project
+        project_path = task_dir / "proj"
+        make_ve_initialized_git_repo(project_path)
+
+        config_content = """external_artifact_repo: acme/ext
+projects:
+  - acme/proj
+"""
+        (task_dir / ".ve-task.yaml").write_text(config_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "create", "memory_leak", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "Failed to resolve HEAD SHA" in result.output

--- a/tests/test_task_investigation_create.py
+++ b/tests/test_task_investigation_create.py
@@ -10,67 +10,7 @@ from click.testing import CliRunner
 
 from ve import cli
 from task_utils import load_external_ref
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "investigations").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 class TestInvestigationCreateInTaskDirectory:

--- a/tests/test_task_investigation_list.py
+++ b/tests/test_task_investigation_list.py
@@ -9,67 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from ve import cli
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "investigations").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 def create_investigation_in_external_repo(

--- a/tests/test_task_investigation_list.py
+++ b/tests/test_task_investigation_list.py
@@ -1,0 +1,261 @@
+"""Integration tests for task-aware investigation listing.
+
+# Chunk: docs/chunks/task_aware_investigations - Task-aware investigation list tests
+"""
+
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from ve import cli
+
+
+def make_ve_initialized_git_repo(path):
+    """Helper to create a VE-initialized git repository with a commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    (path / "docs" / "investigations").mkdir(parents=True)
+    # Create initial commit so HEAD exists
+    (path / "README.md").write_text("# Test\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def setup_task_directory(tmp_path, external_name="ext", project_names=None):
+    """Create a complete task directory setup for testing.
+
+    Returns:
+        tuple: (task_dir, external_path, project_paths)
+    """
+    if project_names is None:
+        project_names = ["proj"]
+
+    task_dir = tmp_path
+
+    # Create external repo
+    external_path = task_dir / external_name
+    make_ve_initialized_git_repo(external_path)
+
+    # Create project repos
+    project_paths = []
+    for name in project_names:
+        project_path = task_dir / name
+        make_ve_initialized_git_repo(project_path)
+        project_paths.append(project_path)
+
+    # Create .ve-task.yaml
+    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
+    config_content = f"""external_artifact_repo: acme/{external_name}
+projects:
+{projects_yaml}
+"""
+    (task_dir / ".ve-task.yaml").write_text(config_content)
+
+    return task_dir, external_path, project_paths
+
+
+def create_investigation_in_external_repo(
+    external_path, short_name, status="ONGOING", dependents=None
+):
+    """Create an investigation directory with OVERVIEW.md in the external repo.
+
+    Args:
+        external_path: Path to the external repository
+        short_name: e.g., "memory_leak"
+        status: Investigation status (default "ONGOING")
+        dependents: List of {artifact_type, artifact_id, repo} dicts (optional)
+
+    Returns:
+        Path to the created investigation directory
+    """
+    investigation_dir = external_path / "docs" / "investigations" / short_name
+    investigation_dir.mkdir(parents=True, exist_ok=True)
+
+    dependents_yaml = ""
+    if dependents:
+        dependents_lines = []
+        for dep in dependents:
+            dependents_lines.append(f"  - artifact_type: {dep['artifact_type']}")
+            dependents_lines.append(f"    artifact_id: {dep['artifact_id']}")
+            dependents_lines.append(f"    repo: {dep['repo']}")
+        dependents_yaml = "dependents:\n" + "\n".join(dependents_lines)
+
+    overview_content = f"""---
+status: {status}
+trigger: null
+proposed_chunks: []
+{dependents_yaml}
+---
+
+# Investigation: {short_name}
+
+## Trigger
+
+Test investigation for {short_name}.
+
+## Testable Hypotheses
+
+No hypotheses yet.
+
+## Exploration Log
+
+No explorations yet.
+
+## Findings
+
+No findings yet.
+"""
+    (investigation_dir / "OVERVIEW.md").write_text(overview_content)
+    return investigation_dir
+
+
+class TestInvestigationListInTaskDirectory:
+    """Tests for ve investigation list in task directory context."""
+
+    def test_lists_investigations_from_external_repo(self, tmp_path):
+        """Lists investigations from external repo when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(tmp_path)
+
+        # Create investigations in external repo
+        create_investigation_in_external_repo(external_path, "memory_leak")
+        create_investigation_in_external_repo(external_path, "slow_query")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "docs/investigations/memory_leak" in result.output
+        assert "docs/investigations/slow_query" in result.output
+
+    def test_shows_dependents_for_each_investigation(self, tmp_path):
+        """Displays dependents for each investigation when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(
+            tmp_path, project_names=["service_a", "service_b"]
+        )
+
+        # Create investigation with dependents in external repo
+        dependents = [
+            {"artifact_type": "investigation", "artifact_id": "memory_leak", "repo": "acme/service_a"},
+            {"artifact_type": "investigation", "artifact_id": "memory_leak", "repo": "acme/service_b"},
+        ]
+        create_investigation_in_external_repo(
+            external_path, "memory_leak", status="ONGOING", dependents=dependents
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "docs/investigations/memory_leak" in result.output
+        assert "dependents:" in result.output
+        assert "acme/service_a" in result.output
+        assert "acme/service_b" in result.output
+
+    def test_shows_status(self, tmp_path):
+        """Displays investigation status when in task directory."""
+        task_dir, external_path, _ = setup_task_directory(tmp_path)
+
+        create_investigation_in_external_repo(external_path, "memory_leak", status="ONGOING")
+        create_investigation_in_external_repo(external_path, "slow_query", status="SOLVED")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "[ONGOING]" in result.output
+        assert "[SOLVED]" in result.output
+
+    def test_error_when_external_repo_inaccessible(self, tmp_path):
+        """Reports clear error when external repo not accessible."""
+        task_dir = tmp_path
+
+        # Create project but not external repo
+        project_path = task_dir / "proj"
+        make_ve_initialized_git_repo(project_path)
+
+        # Create config referencing missing external repo
+        config_content = """external_artifact_repo: acme/missing_ext
+projects:
+  - acme/proj
+"""
+        (task_dir / ".ve-task.yaml").write_text(config_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "External" in result.output
+        assert "not found" in result.output
+
+    def test_error_when_no_investigations_in_external_repo(self, tmp_path):
+        """Reports 'No investigations found' when external repo has no investigations."""
+        task_dir, _, _ = setup_task_directory(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "list", "--project-dir", str(task_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "No investigations found" in result.output
+
+
+class TestInvestigationListOutsideTaskDirectory:
+    """Tests for ve investigation list outside task directory context."""
+
+    def test_single_repo_behavior_unchanged(self, tmp_path):
+        """Single-repo behavior unchanged when not in task directory."""
+        # Create a regular VE project (no .ve-task.yaml)
+        project_path = tmp_path / "regular_project"
+        make_ve_initialized_git_repo(project_path)
+
+        # Create an investigation directly
+        investigation_dir = project_path / "docs" / "investigations" / "my_investigation"
+        investigation_dir.mkdir(parents=True)
+        overview_content = """---
+status: ONGOING
+trigger: null
+proposed_chunks: []
+---
+
+# Investigation
+
+Test investigation.
+"""
+        (investigation_dir / "OVERVIEW.md").write_text(overview_content)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["investigation", "list", "--project-dir", str(project_path)]
+        )
+
+        assert result.exit_code == 0
+        assert "docs/investigations/my_investigation [ONGOING]" in result.output
+        # Should NOT have dependents line in single-repo mode
+        assert "dependents:" not in result.output

--- a/tests/test_task_models.py
+++ b/tests/test_task_models.py
@@ -1,10 +1,11 @@
 """Tests for cross-repository chunk management models."""
-# Chunk: docs/chunks/cross_repo_schemas - Validation tests for TaskConfig, ExternalChunkRef, ChunkDependent
+# Chunk: docs/chunks/cross_repo_schemas - Validation tests for TaskConfig, ChunkDependent
+# Chunk: docs/chunks/consolidate_ext_refs - Validation tests for ExternalArtifactRef
 
 import pytest
 from pydantic import ValidationError
 
-from models import TaskConfig, ExternalChunkRef, ChunkDependent, ExternalArtifactRef, ArtifactType
+from models import TaskConfig, ChunkDependent, ExternalArtifactRef, ArtifactType
 
 
 class TestTaskConfig:
@@ -52,50 +53,6 @@ class TestTaskConfig:
             TaskConfig(
                 external_artifact_repo="acme/sub/chunks",
                 projects=["acme/repo1"],
-            )
-
-
-class TestExternalChunkRef:
-    """Tests for the ExternalChunkRef schema."""
-
-    def test_external_chunk_ref_rejects_missing_org(self):
-        """Rejects repo without org/repo format."""
-        with pytest.raises(ValidationError):
-            ExternalChunkRef(
-                repo="myproject",  # Missing org/
-                chunk="0001-feature",
-            )
-
-    def test_external_chunk_ref_rejects_invalid_repo_chars(self):
-        """Rejects repo with spaces or special characters."""
-        with pytest.raises(ValidationError):
-            ExternalChunkRef(
-                repo="my org/project",  # Space in org
-                chunk="0001-feature",
-            )
-
-    def test_external_chunk_ref_rejects_invalid_chunk(self):
-        """Rejects invalid chunk directory name."""
-        with pytest.raises(ValidationError):
-            ExternalChunkRef(
-                repo="acme/myproject",
-                chunk="chunk with spaces",
-            )
-
-    def test_external_chunk_ref_rejects_invalid_pinned(self):
-        """Rejects pinned SHA that isn't 40 hex characters."""
-        with pytest.raises(ValidationError):
-            ExternalChunkRef(
-                repo="acme/myproject",
-                chunk="0001-feature",
-                pinned="abc123",  # Too short
-            )
-
-        with pytest.raises(ValidationError):
-            ExternalChunkRef(
-                repo="acme/myproject",
-                chunk="0001-feature",
-                pinned="G" * 40,  # Invalid hex character
             )
 
 

--- a/tests/test_task_narrative_create.py
+++ b/tests/test_task_narrative_create.py
@@ -10,67 +10,7 @@ from click.testing import CliRunner
 
 from ve import cli
 from task_utils import load_external_ref
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "narratives").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 class TestNarrativeCreateInTaskDirectory:

--- a/tests/test_task_narrative_list.py
+++ b/tests/test_task_narrative_list.py
@@ -9,67 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from ve import cli
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "narratives").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 def create_narrative_in_external_repo(

--- a/tests/test_task_subsystem_discover.py
+++ b/tests/test_task_subsystem_discover.py
@@ -10,67 +10,7 @@ from click.testing import CliRunner
 
 from ve import cli
 from task_utils import load_external_ref
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "subsystems").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 class TestSubsystemDiscoverInTaskDirectory:

--- a/tests/test_task_subsystem_list.py
+++ b/tests/test_task_subsystem_list.py
@@ -9,67 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from ve import cli
-
-
-def make_ve_initialized_git_repo(path):
-    """Helper to create a VE-initialized git repository with a commit."""
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test.com"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-    (path / "docs" / "subsystems").mkdir(parents=True)
-    # Create initial commit so HEAD exists
-    (path / "README.md").write_text("# Test\n")
-    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=path,
-        check=True,
-        capture_output=True,
-    )
-
-
-def setup_task_directory(tmp_path, external_name="ext", project_names=None):
-    """Create a complete task directory setup for testing.
-
-    Returns:
-        tuple: (task_dir, external_path, project_paths)
-    """
-    if project_names is None:
-        project_names = ["proj"]
-
-    task_dir = tmp_path
-
-    # Create external repo
-    external_path = task_dir / external_name
-    make_ve_initialized_git_repo(external_path)
-
-    # Create project repos
-    project_paths = []
-    for name in project_names:
-        project_path = task_dir / name
-        make_ve_initialized_git_repo(project_path)
-        project_paths.append(project_path)
-
-    # Create .ve-task.yaml
-    projects_yaml = "\n".join(f"  - acme/{name}" for name in project_names)
-    config_content = f"""external_artifact_repo: acme/{external_name}
-projects:
-{projects_yaml}
-"""
-    (task_dir / ".ve-task.yaml").write_text(config_content)
-
-    return task_dir, external_path, project_paths
+from conftest import make_ve_initialized_git_repo, setup_task_directory
 
 
 def create_subsystem_in_external_repo(


### PR DESCRIPTION
## Summary

Extends `ve investigation create` and `ve investigation list` to support task directory context, following the established pattern for chunk and narrative task-aware commands. Investigations can now be created in an external repository with automatic reference creation in participating projects.

## Changes

- Add `dependents` field to InvestigationFrontmatter for cross-repo tracking
- Implement TaskInvestigationError, create_task_investigation(), list_task_investigations() in task_utils.py
- Extend CLI commands with task directory detection
- Add comprehensive integration tests for both create and list operations
- Update workflow_artifacts subsystem documentation

🤖 Generated with Claude Code