### PR TITLE
feat: add ve artifact promote command

### DIFF
--- a/docs/chunks/artifact_promote/GOAL.md
+++ b/docs/chunks/artifact_promote/GOAL.md
@@ -1,0 +1,103 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+  - src/task_utils.py
+  - src/ve.py
+  - tests/test_artifact_promote.py
+code_references:
+  - ref: src/task_utils.py#TaskPromoteError
+    implements: "Exception class for user-friendly promotion error messages"
+  - ref: src/task_utils.py#find_task_directory
+    implements: "Walk up from artifact path to find task directory containing .ve-task.yaml"
+  - ref: src/task_utils.py#identify_source_project
+    implements: "Determine which project (org/repo) contains the artifact being promoted"
+  - ref: src/task_utils.py#add_dependents_to_artifact
+    implements: "Generic helper to add dependents to any artifact type's main file"
+  - ref: src/task_utils.py#_get_artifact_created_after
+    implements: "Parse created_after field from artifact's main file frontmatter"
+  - ref: src/task_utils.py#promote_artifact
+    implements: "Core promotion logic: copy to external repo, update frontmatter, create external.yaml"
+  - ref: src/ve.py#artifact
+    implements: "CLI command group for artifact management commands"
+  - ref: src/ve.py#promote
+    implements: "CLI command ve artifact promote <path> [--name]"
+  - ref: tests/test_artifact_promote.py#TestPromoteArtifactCoreFunction
+    implements: "Unit tests for promote_artifact() function"
+  - ref: tests/test_artifact_promote.py#TestPromoteArtifactCLI
+    implements: "CLI integration tests for ve artifact promote command"
+narrative: null
+subsystems:
+  - subsystem_id: workflow_artifacts
+    relationship: uses
+created_after: ["task_aware_investigations", "task_aware_subsystem_cmds"]
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Add a `ve artifact promote` command that moves a local artifact (chunk, investigation, narrative, or subsystem) from a project's `docs/` directory to the task-level external artifact repository. This addresses a workflow gap discovered during the `xr_vibe_integration` investigation: when an artifact is created locally but later discovered to span multiple projects, there's no way to "promote" it to task-level.
+
+This advances the trunk goal by maintaining document health over time—artifacts should live at the appropriate scope. The workflow should make it easy to correct artifact placement after the fact, supporting the principle that "following the workflow must maintain the health of documents over time."
+
+### Command Signature
+
+```
+ve artifact promote <artifact-path> [--name <new-name>]
+```
+
+- `<artifact-path>`: Path to a local artifact (e.g., `docs/investigations/xr_vibe_integration`)
+- `--name`: Optional new name for the artifact in the destination (enables renaming during promotion)
+
+### Scope
+
+This command is specifically for **task-level promotion**: moving an artifact from a project to the external artifact repository, leaving behind an external reference. For moving artifacts between projects without external references, users should use shell commands (`mv`).
+
+### What the Command Does
+
+1. **Detects context**: Walks up from artifact path to find task directory (`.ve-task.yaml`), identifies source project's org/repo by matching against task config's projects list
+2. **Validates**: Errors if destination artifact already exists in external repo (unless `--name` provides alternate name)
+3. **Copies**: Moves artifact directory to external repo's `docs/<type>/<dest-name>/`
+4. **Updates promoted artifact**: Sets `created_after` to external repo tips (inserting it as newest in external repo's causal chain), adds source project to `dependents`
+5. **Creates reference**: Clears source directory, creates `external.yaml` with `created_after` from the **original artifact** (preserving local causal position)
+6. **Does NOT auto-commit**: Makes filesystem changes only; user commits manually
+
+## Success Criteria
+
+1. **CLI command exists**: `ve artifact promote <artifact-path> [--name <new-name>]` is available
+
+2. **Task context detection**: Walks up from artifact path to find task directory; errors with clear message if not in task context
+
+3. **Project identification**: Determines source project's org/repo by matching artifact path against task config's projects list
+
+4. **Artifact type inference**: Detects artifact type from path structure (`docs/chunks/`, `docs/investigations/`, etc.)
+
+5. **Collision detection**: Errors if destination name already exists in external repo; `--name` flag allows specifying alternate destination name
+
+6. **Move operation**: Copies entire artifact directory to external repo's `docs/<type>/<dest-name>/`, preserving all files and subdirectories
+
+7. **External reference creation**: Clears source directory and creates `external.yaml` with:
+   - `artifact_type`: The detected type
+   - `artifact_id`: The destination name (source name or `--name` value)
+   - `repo`: The external artifact repo from task config
+   - `pinned`: Current SHA of external repo
+   - `created_after`: The **original artifact's** `created_after` value (preserves local causal position)
+
+8. **Promoted artifact causal ordering**: Updates the promoted artifact's `created_after` in its frontmatter to reference the external repo's current tips (inserts it as the newest artifact in the external repo's causal chain)
+
+9. **Dependent tracking**: Updates promoted artifact's frontmatter to add source project to `dependents` list
+
+10. **Idempotency protection**: Refuses to promote artifacts that are already external references (have `external.yaml` without main document)
+
+11. **No auto-commit**: Command makes filesystem changes only; does not run git commands
+
+12. **Tests pass**: Unit tests cover the promote workflow including:
+    - Happy path promotion
+    - `--name` renaming
+    - Collision detection and error
+    - Already-external rejection
+    - Task context detection from nested project directory
+    - Correct `created_after` handling for both promoted artifact and external.yaml
+

--- a/docs/chunks/artifact_promote/PLAN.md
+++ b/docs/chunks/artifact_promote/PLAN.md
@@ -1,0 +1,253 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+This chunk implements `ve artifact promote`, a command that moves a local artifact
+(chunk, narrative, investigation, or subsystem) from a project's `docs/` directory
+to the task-level external artifact repository. The command is specifically for
+task-level promotion when working in a multi-repo task context.
+
+**Strategy**: Follow the established patterns from task-aware artifact commands
+(`create_task_chunk`, `create_task_narrative`, etc.) but operate in reverse—instead
+of creating an artifact in the external repo and references in projects, we move
+an existing local artifact to the external repo and replace it with an external
+reference.
+
+**Key patterns to reuse**:
+- Task context detection via `is_task_directory()` and `load_task_config()`
+- Artifact type detection via `detect_artifact_type_from_path()`
+- External reference creation via `create_external_yaml()`
+- Artifact ordering via `ArtifactIndex` for causal chain management
+- Frontmatter update via `update_frontmatter_field()`
+
+**Test-driven approach**: Following TESTING_PHILOSOPHY.md, write failing tests first
+for the core behaviors, then implement. Focus on semantic assertions (files exist
+in expected locations, frontmatter contains expected values) rather than structural
+assertions.
+
+## Subsystem Considerations
+
+- **docs/subsystems/workflow_artifacts** (STABLE): This chunk USES the workflow_artifacts
+  subsystem for external reference patterns, artifact type detection, causal ordering,
+  and frontmatter schemas. The subsystem already defines:
+  - `ExternalArtifactRef` model for external.yaml files
+  - `ArtifactIndex` for causal ordering and tip detection
+  - `create_external_yaml()` for creating external references
+  - `detect_artifact_type_from_path()` for inferring artifact type
+  - `ARTIFACT_DIR_NAME` and `ARTIFACT_MAIN_FILE` constants
+
+  This chunk will add a new function (`promote_artifact()`) following the established
+  patterns in `task_utils.py`. No deviations expected—the subsystem is STABLE and
+  provides all necessary building blocks.
+
+## Sequence
+
+### Step 1: Write failing tests for promote_artifact core function
+
+Create `tests/test_artifact_promote.py` with tests covering the core promotion logic:
+
+1. **Happy path**: Promotes a local investigation to external repo
+   - Source artifact directory is copied to external repo's docs/<type>/
+   - Source directory is cleared and external.yaml is created
+   - External.yaml contains correct artifact_type, artifact_id, repo, pinned, created_after
+   - Promoted artifact's frontmatter has updated created_after (external repo tips)
+   - Promoted artifact's frontmatter has dependents list containing source project
+
+2. **--name flag**: Renames artifact during promotion
+   - Artifact copied to external repo with new name
+   - External.yaml references the new name as artifact_id
+
+3. **Collision detection**: Errors when destination exists
+   - Returns error if artifact with same name exists in external repo
+   - Error message is user-friendly
+
+4. **Already-external rejection**: Errors for external references
+   - Returns error if artifact is already an external reference (has external.yaml, no main doc)
+   - Error message explains the artifact is already external
+
+5. **Task context detection**: Errors when not in task context
+   - Returns error with clear message if not in task directory
+
+6. **created_after preservation**: External.yaml preserves original causal position
+   - External.yaml's created_after matches the original artifact's created_after field
+
+Location: tests/test_artifact_promote.py
+
+### Step 2: Implement TaskPromoteError and promote_artifact function
+
+Add to `src/task_utils.py`:
+
+1. **TaskPromoteError** exception class for user-friendly error messages
+
+2. **promote_artifact()** function that:
+   - Validates the artifact path exists and contains a main document
+   - Detects artifact type from path
+   - Walks up to find task directory (`.ve-task.yaml`)
+   - Identifies source project from task config's projects list
+   - Checks for collision in external repo (error if exists, unless --name provides alternate)
+   - Copies artifact directory to external repo's docs/<type>/<dest-name>/
+   - Gets current tips from external repo for the artifact's created_after
+   - Updates promoted artifact's frontmatter: sets created_after to external tips, adds source project to dependents
+   - Saves the original artifact's created_after field before clearing
+   - Clears source directory and creates external.yaml with the saved created_after
+
+Parameters:
+- artifact_path: Path to local artifact directory
+- new_name: Optional new name for destination (--name flag value)
+
+Returns:
+- Dict with external_artifact_path, external_yaml_path
+
+Location: src/task_utils.py
+
+### Step 3: Implement find_task_directory helper
+
+Add helper function to walk up from a path to find the task directory:
+
+```python
+def find_task_directory(start_path: Path) -> Path | None:
+    """Walk up from start_path to find directory containing .ve-task.yaml."""
+```
+
+This is needed because promote is called with an artifact path that may be
+nested inside a project within the task directory.
+
+Location: src/task_utils.py
+
+### Step 4: Implement identify_source_project helper
+
+Add helper to identify which project in task config contains the artifact:
+
+```python
+def identify_source_project(task_dir: Path, artifact_path: Path, config: TaskConfig) -> str:
+    """Determine which project (org/repo format) contains the artifact."""
+```
+
+Matches artifact_path against each project in config.projects by resolving
+project paths and checking if artifact_path is within that project.
+
+Location: src/task_utils.py
+
+### Step 5: Implement add_dependents helper for all artifact types
+
+Generalize the existing `add_dependents_to_chunk/narrative/investigation/subsystem`
+helpers into a single generic helper:
+
+```python
+def add_dependents_to_artifact(
+    artifact_path: Path,
+    artifact_type: ArtifactType,
+    dependents: list[dict],
+) -> None:
+```
+
+Uses `ARTIFACT_MAIN_FILE` to determine the correct file to update.
+
+Location: src/task_utils.py
+
+### Step 6: Write failing CLI tests
+
+Add CLI tests to `tests/test_artifact_promote.py`:
+
+1. **CLI exists**: `ve artifact promote <path>` command exists
+2. **Validates path exists**: Errors for non-existent path
+3. **--name flag works**: Renames during promotion
+4. **Output format**: Reports success with paths
+5. **No git commands**: Verifies no auto-commit (filesystem changes only)
+
+### Step 7: Implement CLI command
+
+Add `artifact` command group and `promote` subcommand to `src/ve.py`:
+
+```python
+@cli.group()
+def artifact():
+    """Artifact management commands."""
+    pass
+
+@artifact.command()
+@click.argument("artifact_path", type=click.Path(exists=True, path_type=pathlib.Path))
+@click.option("--name", "new_name", type=str, help="New name for artifact in destination")
+def promote(artifact_path, new_name):
+    """Promote a local artifact to the task-level external repository."""
+```
+
+The CLI:
+- Validates artifact_path points to a valid artifact directory
+- Calls promote_artifact() from task_utils
+- Reports created paths to user
+- Does NOT run any git commands
+
+Location: src/ve.py
+
+### Step 8: Run tests and fix any issues
+
+Execute the full test suite to verify:
+- All new tests pass
+- No regressions in existing tests
+- Tests cover the success criteria from GOAL.md
+
+```bash
+uv run pytest tests/test_artifact_promote.py -v
+uv run pytest tests/ -v
+```
+
+---
+
+**BACKREFERENCE COMMENTS**
+
+Add chunk backreferences at function level:
+```python
+# Chunk: docs/chunks/artifact_promote - Artifact promotion to external repo
+```
+
+## Dependencies
+
+No new external libraries required. All dependencies are already in place:
+- `shutil` from Python standard library for directory copy operations
+- Existing task_utils.py infrastructure for task context detection
+- Existing external_refs.py utilities for external reference handling
+- Existing artifact_ordering.py for causal ordering
+
+## Risks and Open Questions
+
+1. **Filesystem atomicity**: The promote operation involves multiple steps (copy,
+   update frontmatter, clear source, create external.yaml). If interrupted mid-way,
+   the artifact could be in an inconsistent state. Mitigation: Document that users
+   should use git to recover if interrupted; the command does not auto-commit so
+   partial changes are visible.
+
+2. **Collision with --name**: If `--name` is provided but an artifact with that name
+   already exists in the external repo, we error. This is intentional—the user should
+   pick a unique name or handle the collision manually.
+
+3. **Existing external.yaml with content**: When clearing the source directory, we
+   preserve only the external.yaml pattern. If there are other files (e.g., notes,
+   scratch files), they will be deleted. This matches the existing pattern where
+   external artifact directories contain only external.yaml.
+
+## Deviations
+
+<!--
+POPULATE DURING IMPLEMENTATION, not at planning time.
+
+When reality diverges from the plan, document it here:
+- What changed?
+- Why?
+- What was the impact?
+
+Minor deviations (renamed a function, used a different helper) don't need
+documentation. Significant deviations (changed the approach, skipped a step,
+added steps) do.
+
+Example:
+- Step 4: Originally planned to use std::fs::rename for atomic swap.
+  Testing revealed this isn't atomic across filesystems. Changed to
+  write-fsync-rename-fsync sequence per platform best practices.
+-->

--- a/docs/investigations/xr_vibe_integration/OVERVIEW.md
+++ b/docs/investigations/xr_vibe_integration/OVERVIEW.md
@@ -9,7 +9,7 @@ proposed_chunks:
   - prompt: "Extend xr architecture command to include ve artifact information for ve-enabled repos"
     chunk_directory: null
   - prompt: "Add ve artifact promote command to move local artifacts to task-level external artifact repo"
-    chunk_directory: null
+    chunk_directory: artifact_promote
 created_after: ["alphabetical_chunk_grouping"]
 ---
 

--- a/src/task_utils.py
+++ b/src/task_utils.py
@@ -1011,3 +1011,301 @@ def list_task_subsystems(task_dir: Path) -> list[dict]:
         })
 
     return results
+
+
+# Chunk: docs/chunks/artifact_promote - Task promote error class
+class TaskPromoteError(Exception):
+    """Error during artifact promotion with user-friendly message."""
+
+    pass
+
+
+# Chunk: docs/chunks/artifact_promote - Find task directory from artifact path
+def find_task_directory(start_path: Path) -> Path | None:
+    """Walk up from start_path to find directory containing .ve-task.yaml.
+
+    Args:
+        start_path: Starting path to search from.
+
+    Returns:
+        Path to the task directory, or None if not found.
+    """
+    current = start_path.resolve()
+
+    # Walk up the directory tree
+    while current != current.parent:
+        if (current / ".ve-task.yaml").exists():
+            return current
+        current = current.parent
+
+    # Check root as well
+    if (current / ".ve-task.yaml").exists():
+        return current
+
+    return None
+
+
+# Chunk: docs/chunks/artifact_promote - Identify source project from artifact path
+def identify_source_project(task_dir: Path, artifact_path: Path, config: TaskConfig) -> str:
+    """Determine which project (org/repo format) contains the artifact.
+
+    Args:
+        task_dir: The task directory containing .ve-task.yaml.
+        artifact_path: Path to the artifact being promoted.
+        config: Loaded task configuration.
+
+    Returns:
+        The project reference in org/repo format.
+
+    Raises:
+        TaskPromoteError: If artifact is not within any configured project.
+    """
+    artifact_resolved = artifact_path.resolve()
+
+    for project_ref in config.projects:
+        try:
+            project_path = resolve_repo_directory(task_dir, project_ref)
+            project_resolved = project_path.resolve()
+
+            # Check if artifact_path is within this project
+            try:
+                artifact_resolved.relative_to(project_resolved)
+                return project_ref
+            except ValueError:
+                continue
+        except FileNotFoundError:
+            continue
+
+    raise TaskPromoteError(
+        f"Artifact '{artifact_path}' is not within any configured project. "
+        f"Projects: {', '.join(config.projects)}"
+    )
+
+
+# Chunk: docs/chunks/artifact_promote - Generic add_dependents helper
+def add_dependents_to_artifact(
+    artifact_path: Path,
+    artifact_type: ArtifactType,
+    dependents: list[dict],
+) -> None:
+    """Update artifact's main file frontmatter to include dependents list.
+
+    Args:
+        artifact_path: Path to the artifact directory.
+        artifact_type: Type of artifact to determine main file.
+        dependents: List of {artifact_type, artifact_id, repo} dicts.
+
+    Raises:
+        FileNotFoundError: If main file doesn't exist in artifact_path.
+    """
+    main_file = ARTIFACT_MAIN_FILE[artifact_type]
+    main_path = artifact_path / main_file
+
+    if not main_path.exists():
+        raise FileNotFoundError(f"{main_file} not found in {artifact_path}")
+
+    update_frontmatter_field(main_path, "dependents", dependents)
+
+
+# Chunk: docs/chunks/artifact_promote - Parse frontmatter for created_after
+def _get_artifact_created_after(artifact_path: Path, artifact_type: ArtifactType) -> list[str]:
+    """Get the created_after field from an artifact's main file.
+
+    Args:
+        artifact_path: Path to the artifact directory.
+        artifact_type: Type of artifact to determine main file.
+
+    Returns:
+        List of artifact names from created_after, or empty list.
+    """
+    main_file = ARTIFACT_MAIN_FILE[artifact_type]
+    main_path = artifact_path / main_file
+
+    if not main_path.exists():
+        return []
+
+    import re as _re
+    content = main_path.read_text()
+
+    # Parse frontmatter
+    match = _re.match(r"^---\s*\n(.*?)\n---\s*\n", content, _re.DOTALL)
+    if not match:
+        return []
+
+    frontmatter = yaml.safe_load(match.group(1)) or {}
+    created_after = frontmatter.get("created_after", [])
+
+    if created_after is None:
+        return []
+    if isinstance(created_after, str):
+        return [created_after]
+    if isinstance(created_after, list):
+        return created_after
+
+    return []
+
+
+# Chunk: docs/chunks/artifact_promote - Promote artifact to external repo
+def promote_artifact(
+    artifact_path: Path,
+    new_name: str | None = None,
+) -> dict:
+    """Promote a local artifact to the task-level external repository.
+
+    Orchestrates artifact promotion:
+    1. Validates artifact is local (not already external)
+    2. Detects artifact type from path
+    3. Finds task directory and loads config
+    4. Identifies source project
+    5. Checks for collision in external repo
+    6. Copies artifact directory to external repo
+    7. Updates promoted artifact's created_after to external tips
+    8. Updates promoted artifact's dependents with source project
+    9. Creates external.yaml in source, preserving original created_after
+
+    Args:
+        artifact_path: Path to the local artifact directory.
+        new_name: Optional new name for destination (--name flag value).
+
+    Returns:
+        Dict with keys:
+        - external_artifact_path: Path to promoted artifact in external repo
+        - external_yaml_path: Path to created external.yaml in source
+
+    Raises:
+        TaskPromoteError: If any step fails, with user-friendly message.
+    """
+    import shutil
+    from external_refs import (
+        detect_artifact_type_from_path,
+        is_external_artifact,
+        ARTIFACT_DIR_NAME,
+    )
+
+    artifact_path = Path(artifact_path).resolve()
+
+    # 1. Validate artifact exists and has a main document
+    if not artifact_path.exists():
+        raise TaskPromoteError(f"Artifact path does not exist: {artifact_path}")
+
+    if not artifact_path.is_dir():
+        raise TaskPromoteError(f"Artifact path is not a directory: {artifact_path}")
+
+    # 2. Detect artifact type from path
+    try:
+        artifact_type = detect_artifact_type_from_path(artifact_path)
+    except ValueError as e:
+        raise TaskPromoteError(str(e))
+
+    # Check if already external
+    if is_external_artifact(artifact_path, artifact_type):
+        raise TaskPromoteError(
+            f"Artifact '{artifact_path.name}' is already an external reference. "
+            f"Cannot promote an artifact that is already external."
+        )
+
+    # Verify main file exists
+    main_file = ARTIFACT_MAIN_FILE[artifact_type]
+    if not (artifact_path / main_file).exists():
+        raise TaskPromoteError(
+            f"Artifact '{artifact_path.name}' does not have a {main_file} file. "
+            f"Only local artifacts with main documents can be promoted."
+        )
+
+    # 3. Find task directory
+    task_dir = find_task_directory(artifact_path)
+    if task_dir is None:
+        raise TaskPromoteError(
+            f"Cannot find task directory (.ve-task.yaml) above '{artifact_path}'. "
+            f"Artifact promotion requires a task context."
+        )
+
+    # Load task config
+    try:
+        config = load_task_config(task_dir)
+    except FileNotFoundError:
+        raise TaskPromoteError(
+            f"Task configuration not found. Expected .ve-task.yaml in {task_dir}"
+        )
+
+    # 4. Identify source project
+    source_project = identify_source_project(task_dir, artifact_path, config)
+
+    # 5. Resolve external repo and check for collision
+    try:
+        external_repo_path = resolve_repo_directory(task_dir, config.external_artifact_repo)
+    except FileNotFoundError:
+        raise TaskPromoteError(
+            f"External artifact repository '{config.external_artifact_repo}' not found"
+        )
+
+    # Determine destination name
+    dest_name = new_name if new_name else artifact_path.name
+    dir_name = ARTIFACT_DIR_NAME[artifact_type]
+    dest_path = external_repo_path / "docs" / dir_name / dest_name
+
+    if dest_path.exists():
+        raise TaskPromoteError(
+            f"Artifact '{dest_name}' already exists in external repository at {dest_path}. "
+            f"Use --name to specify a different name."
+        )
+
+    # 6. Get current SHA from external repo for pinned
+    try:
+        pinned_sha = get_current_sha(external_repo_path)
+    except ValueError as e:
+        raise TaskPromoteError(
+            f"Failed to resolve HEAD SHA in external repository: {e}"
+        )
+
+    # Save original created_after before copying
+    original_created_after = _get_artifact_created_after(artifact_path, artifact_type)
+
+    # 7. Copy artifact directory to external repo
+    shutil.copytree(artifact_path, dest_path)
+
+    # 8. Get external repo tips for the promoted artifact's created_after
+    try:
+        external_index = ArtifactIndex(external_repo_path)
+        external_tips = external_index.find_tips(artifact_type)
+        # Exclude the just-copied artifact from tips (it's not in the index yet)
+        external_tips = [t for t in external_tips if t != dest_name]
+    except Exception:
+        external_tips = []
+
+    # Update promoted artifact's created_after to external tips
+    dest_main_path = dest_path / main_file
+    if external_tips:
+        update_frontmatter_field(dest_main_path, "created_after", external_tips)
+
+    # 9. Update promoted artifact's dependents with source project
+    dependent_entry = {
+        "artifact_type": artifact_type.value,
+        "artifact_id": artifact_path.name,  # Original name in source project
+        "repo": source_project,
+    }
+    add_dependents_to_artifact(dest_path, artifact_type, [dependent_entry])
+
+    # 10. Clear source directory and create external.yaml
+    # Remove all files from source directory
+    for item in artifact_path.iterdir():
+        if item.is_file():
+            item.unlink()
+        elif item.is_dir():
+            shutil.rmtree(item)
+
+    # Create external.yaml with original created_after
+    external_yaml_path = create_external_yaml(
+        project_path=artifact_path.parent.parent.parent,  # Go up from artifact to project root
+        short_name=artifact_path.name,
+        external_repo_ref=config.external_artifact_repo,
+        external_artifact_id=dest_name,
+        pinned_sha=pinned_sha,
+        created_after=original_created_after,
+        artifact_type=artifact_type,
+    )
+
+    return {
+        "external_artifact_path": dest_path,
+        "external_yaml_path": external_yaml_path,
+    }

--- a/tests/test_artifact_promote.py
+++ b/tests/test_artifact_promote.py
@@ -1,0 +1,540 @@
+"""Tests for artifact promotion to external repository.
+
+# Chunk: docs/chunks/artifact_promote - Artifact promotion tests
+"""
+
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from ve import cli
+from task_utils import (
+    promote_artifact,
+    TaskPromoteError,
+    load_external_ref,
+    load_task_config,
+)
+from conftest import make_ve_initialized_git_repo, setup_task_directory
+
+
+class TestPromoteArtifactCoreFunction:
+    """Tests for the promote_artifact() core function."""
+
+    def test_happy_path_promotes_local_investigation(self, tmp_path):
+        """Promotes a local investigation to external repo."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local investigation in the project
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+trigger: Memory issues observed
+created_after: []
+---
+
+# Investigation: Memory Leak
+
+## Trigger
+Memory issues observed in production.
+""")
+
+        # Promote it
+        result = promote_artifact(investigation_dir)
+
+        # Verify artifact was copied to external repo
+        external_inv_dir = external_path / "docs" / "investigations" / "memory_leak"
+        assert external_inv_dir.exists()
+        assert (external_inv_dir / "OVERVIEW.md").exists()
+
+        # Verify source directory now has external.yaml
+        assert (investigation_dir / "external.yaml").exists()
+        # Source should NOT have OVERVIEW.md anymore
+        assert not (investigation_dir / "OVERVIEW.md").exists()
+
+        # Verify external.yaml content
+        ref = load_external_ref(investigation_dir)
+        assert ref.artifact_type.value == "investigation"
+        assert ref.artifact_id == "memory_leak"
+        assert ref.repo == "acme/ext"
+        assert len(ref.pinned) == 40  # SHA
+
+        # Verify result contains paths
+        assert result["external_artifact_path"] == external_inv_dir
+        assert result["external_yaml_path"] == investigation_dir / "external.yaml"
+
+    def test_promoted_artifact_has_updated_created_after(self, tmp_path):
+        """Promoted artifact's created_after is set to external repo tips."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create an existing investigation in external repo to be a tip
+        existing_inv_dir = external_path / "docs" / "investigations" / "existing_inv"
+        existing_inv_dir.mkdir(parents=True)
+        (existing_inv_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Existing Investigation
+""")
+
+        # Create a local investigation in the project
+        investigation_dir = project_path / "docs" / "investigations" / "new_inv"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# New Investigation
+""")
+
+        # Promote it
+        promote_artifact(investigation_dir)
+
+        # Verify promoted artifact's created_after includes the external tip
+        external_inv_dir = external_path / "docs" / "investigations" / "new_inv"
+        content = (external_inv_dir / "OVERVIEW.md").read_text()
+        assert "existing_inv" in content
+
+    def test_promoted_artifact_has_dependents_set(self, tmp_path):
+        """Promoted artifact's dependents includes source project."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local investigation in the project
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        # Promote it
+        promote_artifact(investigation_dir)
+
+        # Verify dependents in promoted artifact
+        external_inv_dir = external_path / "docs" / "investigations" / "memory_leak"
+        content = (external_inv_dir / "OVERVIEW.md").read_text()
+        assert "dependents:" in content
+        assert "acme/proj" in content
+
+    def test_external_yaml_preserves_original_created_after(self, tmp_path):
+        """External.yaml's created_after matches original artifact's created_after."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create an existing local investigation that will be a dependency
+        other_inv_dir = project_path / "docs" / "investigations" / "other_inv"
+        other_inv_dir.mkdir(parents=True)
+        (other_inv_dir / "OVERVIEW.md").write_text("""---
+status: SOLVED
+created_after: []
+---
+
+# Other Investigation
+""")
+
+        # Create the investigation to promote, with created_after referencing other_inv
+        investigation_dir = project_path / "docs" / "investigations" / "my_inv"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after:
+  - other_inv
+---
+
+# My Investigation
+""")
+
+        # Promote it
+        promote_artifact(investigation_dir)
+
+        # Verify external.yaml preserves the original created_after
+        ref = load_external_ref(investigation_dir)
+        assert ref.created_after == ["other_inv"]
+
+    def test_name_flag_renames_artifact_during_promotion(self, tmp_path):
+        """--name flag renames artifact in destination."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local investigation
+        investigation_dir = project_path / "docs" / "investigations" / "old_name"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        # Promote with new name
+        result = promote_artifact(investigation_dir, new_name="new_name")
+
+        # Verify artifact was created with new name in external repo
+        external_inv_dir = external_path / "docs" / "investigations" / "new_name"
+        assert external_inv_dir.exists()
+
+        # Verify old name doesn't exist in external
+        assert not (external_path / "docs" / "investigations" / "old_name").exists()
+
+        # Verify external.yaml references the new name
+        ref = load_external_ref(investigation_dir)
+        assert ref.artifact_id == "new_name"
+
+    def test_errors_when_destination_exists(self, tmp_path):
+        """Errors if destination artifact already exists in external repo."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create conflicting investigation in external repo
+        existing_dir = external_path / "docs" / "investigations" / "memory_leak"
+        existing_dir.mkdir(parents=True)
+        (existing_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Existing Investigation
+""")
+
+        # Create local investigation with same name
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Local Investigation
+""")
+
+        # Attempt to promote should error
+        with pytest.raises(TaskPromoteError) as exc_info:
+            promote_artifact(investigation_dir)
+
+        assert "already exists" in str(exc_info.value)
+
+    def test_errors_for_already_external_artifact(self, tmp_path):
+        """Errors when artifact is already an external reference."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create an external reference (not a local artifact)
+        investigation_dir = project_path / "docs" / "investigations" / "external_inv"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "external.yaml").write_text("""artifact_type: investigation
+artifact_id: external_inv
+repo: acme/other
+track: main
+pinned: abcd1234abcd1234abcd1234abcd1234abcd1234
+""")
+
+        # Attempt to promote should error
+        with pytest.raises(TaskPromoteError) as exc_info:
+            promote_artifact(investigation_dir)
+
+        assert "already external" in str(exc_info.value).lower()
+
+    def test_errors_when_not_in_task_context(self, tmp_path):
+        """Errors with clear message if not in task directory."""
+        # Create a standalone project (no .ve-task.yaml)
+        project_path = tmp_path / "standalone"
+        make_ve_initialized_git_repo(project_path)
+
+        # Create a local investigation
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        # Attempt to promote should error
+        with pytest.raises(TaskPromoteError) as exc_info:
+            promote_artifact(investigation_dir)
+
+        assert "task" in str(exc_info.value).lower()
+
+    def test_promotes_chunk_artifact(self, tmp_path):
+        """Promotes a chunk artifact correctly."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local chunk
+        chunk_dir = project_path / "docs" / "chunks" / "my_feature"
+        chunk_dir.mkdir(parents=True)
+        (chunk_dir / "GOAL.md").write_text("""---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths: []
+code_references: []
+created_after: []
+---
+
+# Chunk Goal
+
+A feature chunk.
+""")
+        (chunk_dir / "PLAN.md").write_text("""# Plan
+
+Implementation plan here.
+""")
+
+        # Promote it
+        result = promote_artifact(chunk_dir)
+
+        # Verify both files were copied
+        external_chunk_dir = external_path / "docs" / "chunks" / "my_feature"
+        assert (external_chunk_dir / "GOAL.md").exists()
+        assert (external_chunk_dir / "PLAN.md").exists()
+
+        # Verify source is now external reference
+        assert (chunk_dir / "external.yaml").exists()
+        assert not (chunk_dir / "GOAL.md").exists()
+        assert not (chunk_dir / "PLAN.md").exists()
+
+        ref = load_external_ref(chunk_dir)
+        assert ref.artifact_type.value == "chunk"
+
+    def test_promotes_narrative_artifact(self, tmp_path):
+        """Promotes a narrative artifact correctly."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local narrative
+        narrative_dir = project_path / "docs" / "narratives" / "my_story"
+        narrative_dir.mkdir(parents=True)
+        (narrative_dir / "OVERVIEW.md").write_text("""---
+status: ACTIVE
+created_after: []
+---
+
+# Narrative
+
+A story.
+""")
+
+        # Promote it
+        result = promote_artifact(narrative_dir)
+
+        # Verify narrative was promoted
+        external_narrative_dir = external_path / "docs" / "narratives" / "my_story"
+        assert (external_narrative_dir / "OVERVIEW.md").exists()
+
+        ref = load_external_ref(narrative_dir)
+        assert ref.artifact_type.value == "narrative"
+
+    def test_promotes_subsystem_artifact(self, tmp_path):
+        """Promotes a subsystem artifact correctly."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local subsystem
+        subsystem_dir = project_path / "docs" / "subsystems" / "my_subsystem"
+        subsystem_dir.mkdir(parents=True)
+        (subsystem_dir / "OVERVIEW.md").write_text("""---
+status: STABLE
+created_after: []
+---
+
+# Subsystem
+
+A subsystem.
+""")
+
+        # Promote it
+        result = promote_artifact(subsystem_dir)
+
+        # Verify subsystem was promoted
+        external_subsystem_dir = external_path / "docs" / "subsystems" / "my_subsystem"
+        assert (external_subsystem_dir / "OVERVIEW.md").exists()
+
+        ref = load_external_ref(subsystem_dir)
+        assert ref.artifact_type.value == "subsystem"
+
+
+class TestPromoteArtifactCLI:
+    """Tests for ve artifact promote CLI command."""
+
+    def test_cli_command_exists(self, tmp_path):
+        """ve artifact promote command exists."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["artifact", "promote", "--help"])
+
+        assert result.exit_code == 0
+        assert "promote" in result.output.lower()
+
+    def test_cli_validates_path_exists(self, tmp_path):
+        """CLI errors for non-existent path."""
+        task_dir, _, _ = setup_task_directory(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["artifact", "promote", str(task_dir / "nonexistent"), "--project-dir", str(task_dir)],
+        )
+
+        assert result.exit_code != 0
+
+    def test_cli_promotes_investigation(self, tmp_path):
+        """CLI promotes investigation and reports success."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local investigation
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["artifact", "promote", str(investigation_dir), "--project-dir", str(task_dir)],
+        )
+
+        assert result.exit_code == 0
+        assert "memory_leak" in result.output
+
+        # Verify artifact was promoted
+        assert (external_path / "docs" / "investigations" / "memory_leak" / "OVERVIEW.md").exists()
+        assert (investigation_dir / "external.yaml").exists()
+
+    def test_cli_name_flag_works(self, tmp_path):
+        """CLI --name flag renames during promotion."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local investigation
+        investigation_dir = project_path / "docs" / "investigations" / "old_name"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "artifact", "promote", str(investigation_dir),
+                "--name", "new_name",
+                "--project-dir", str(task_dir),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (external_path / "docs" / "investigations" / "new_name" / "OVERVIEW.md").exists()
+
+    def test_cli_no_git_commands(self, tmp_path):
+        """CLI does not run git commands (filesystem changes only)."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Get initial git status
+        initial_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+
+        # Create a local investigation
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["artifact", "promote", str(investigation_dir), "--project-dir", str(task_dir)],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify changes are uncommitted (no git add/commit was run)
+        final_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+        # There should be uncommitted changes
+        assert final_status.stdout.strip() != ""
+
+    def test_cli_reports_paths(self, tmp_path):
+        """CLI output includes created paths."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create a local investigation
+        investigation_dir = project_path / "docs" / "investigations" / "memory_leak"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "OVERVIEW.md").write_text("""---
+status: ONGOING
+created_after: []
+---
+
+# Investigation
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["artifact", "promote", str(investigation_dir), "--project-dir", str(task_dir)],
+        )
+
+        assert result.exit_code == 0
+        # Should mention the external path and the reference
+        assert "external" in result.output.lower() or "promoted" in result.output.lower()
+
+    def test_cli_errors_for_already_external(self, tmp_path):
+        """CLI errors with clear message for already-external artifacts."""
+        task_dir, external_path, project_paths = setup_task_directory(tmp_path)
+        project_path = project_paths[0]
+
+        # Create an external reference
+        investigation_dir = project_path / "docs" / "investigations" / "ext_inv"
+        investigation_dir.mkdir(parents=True)
+        (investigation_dir / "external.yaml").write_text("""artifact_type: investigation
+artifact_id: ext_inv
+repo: acme/other
+track: main
+pinned: abcd1234abcd1234abcd1234abcd1234abcd1234
+""")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["artifact", "promote", str(investigation_dir), "--project-dir", str(task_dir)],
+        )
+
+        assert result.exit_code != 0
+        assert "external" in result.output.lower()


### PR DESCRIPTION
Add a new `ve artifact promote` command that moves local artifacts (chunks, investigations, narratives, subsystems) from a project's docs/ directory to the task-level external artifact repository, leaving behind an external reference. This solves a workflow gap where artifacts created locally are later discovered to span multiple projects and need to be promoted to task scope.

The command detects task context, validates the artifact, copies it to the external repo with updated causal ordering, and creates an external reference in the source preserving local causal position. All tests pass covering the happy path, renaming, collision detection, error cases, and task context detection.

Resolves xr_vibe_integration investigation proposed chunk for artifact promotion.