### PR TITLE
Add grouped artifact listing for task context

### DIFF
--- a/docs/chunks/task_status_command/GOAL.md
+++ b/docs/chunks/task_status_command/GOAL.md
@@ -1,0 +1,85 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+- src/task_utils.py
+- src/ve.py
+- tests/test_task_chunk_list.py
+- tests/test_task_narrative_list.py
+- tests/test_task_investigation_list.py
+- tests/test_task_subsystem_list.py
+- docs/subsystems/workflow_artifacts/OVERVIEW.md
+code_references:
+- ref: src/task_utils.py#TaskArtifactListError
+  implements: Error class for task artifact listing failures
+- ref: src/task_utils.py#_list_local_artifacts
+  implements: List local artifacts for a project, excluding external references
+- ref: src/task_utils.py#list_task_artifacts_grouped
+  implements: Grouped task artifact listing with external and local sections
+- ref: src/ve.py#_format_grouped_artifact_list
+  implements: Output formatter for grouped artifact listing display
+- ref: src/ve.py#_list_task_chunks
+  implements: Updated CLI handler for task-aware chunk listing with grouped output
+- ref: src/ve.py#_list_task_narratives
+  implements: Updated CLI handler for task-aware narrative listing with grouped output
+- ref: src/ve.py#_list_task_investigations
+  implements: Updated CLI handler for task-aware investigation listing with grouped output
+- ref: src/ve.py#_list_task_subsystems
+  implements: Updated CLI handler for task-aware subsystem listing with grouped output
+- ref: tests/test_task_chunk_list.py
+  implements: Tests for grouped chunk listing in task context
+- ref: tests/test_task_narrative_list.py
+  implements: Tests for grouped narrative listing in task context
+- ref: tests/test_task_investigation_list.py
+  implements: Tests for grouped investigation listing in task context
+- ref: tests/test_task_subsystem_list.py
+  implements: Tests for grouped subsystem listing in task context
+- ref: docs/subsystems/workflow_artifacts/OVERVIEW.md
+  implements: Subsystem documentation update for grouped listing behavior
+narrative: null
+subsystems:
+- subsystem_id: workflow_artifacts
+  relationship: implements
+created_after: ["task_aware_investigations", "task_aware_subsystem_cmds"]
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Enhance artifact list commands (`ve chunk list`, `ve narrative list`, `ve subsystem list`, `ve investigation list`) to show grouped-by-location output when running from a task context. Currently, these commands only show artifacts from the external repo when at task root. The new behavior shows the complete cross-project picture: external repo artifacts first, then each participating project's local artifacts, with each group preserving its own causal ordering.
+
+This is an extension to the workflow_artifacts subsystem—the grouped listing concept should be documented there and the implementation should comply with subsystem patterns.
+
+## Success Criteria
+
+1. **Default task context behavior**: Running `ve {artifact} list` from a task root directory shows artifacts grouped by location:
+   - External repo artifacts first (labeled with the external repo org/repo)
+   - Each participating project's local artifacts (labeled with org/repo)
+   - Each group preserves its own causal ordering (topological sort by `created_after`)
+
+2. **Output format**:
+   ```
+   # External Artifacts (org/external-repo)
+   cross_cutting_feature [IMPLEMENTING] (tip)
+     → referenced by: org/project-a, org/project-b
+
+   # org/project-a (local)
+   local_fix_a [ACTIVE] (tip)
+
+   # org/project-b (local)
+   local_fix_b [IMPLEMENTING] (tip)
+   ```
+
+   External artifacts show which projects reference them (from the `dependents` field in frontmatter). Local artifacts in each project section do not show references.
+
+3. **All artifact types supported**: The grouped listing works for chunks, narratives, subsystems, and investigations. Non-task context behavior remains unchanged.
+
+4. **Subsystem documentation**: Add a new section to `docs/subsystems/workflow_artifacts/OVERVIEW.md` documenting the grouped listing behavior for task contexts.
+
+5. **Tests verify**:
+   - Grouped output format for each artifact type
+   - Per-group causal ordering is preserved
+   - Non-task context behavior unchanged
+

--- a/docs/chunks/task_status_command/PLAN.md
+++ b/docs/chunks/task_status_command/PLAN.md
@@ -1,0 +1,203 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+This chunk enhances the artifact list commands (`ve chunk list`, `ve narrative list`, `ve subsystem list`, `ve investigation list`) to show a grouped-by-location output when running from a task directory context. Currently, these commands show only artifacts from the external repo when at task root. The new behavior shows the complete cross-project picture: external repo artifacts first, then each participating project's local artifacts, with each group preserving its own causal ordering.
+
+**Strategy:**
+
+1. Add a new function in `task_utils.py` that collects artifacts from ALL locations in a task (external repo + each project) and groups them by source.
+2. Update the `_list_task_*` handler functions in `ve.py` to use this grouped output format.
+3. Preserve backward compatibility: non-task context behavior remains unchanged.
+4. The same grouped listing behavior applies to all four artifact types (chunks, narratives, subsystems, investigations).
+
+**Patterns to follow:**
+
+- Follow the existing `list_task_chunks()` pattern in `task_utils.py:354-403`
+- Use `ArtifactIndex` for per-project causal ordering (per workflow_artifacts subsystem)
+- The grouped output format uses "External Artifacts" header for the external repo and "org/repo (local)" for each project
+
+**Output format per success criteria:**
+```
+# External Artifacts (org/external-repo)
+cross_cutting_feature [IMPLEMENTING] (tip)
+  → referenced by: org/project-a, org/project-b
+
+# org/project-a (local)
+local_fix_a [ACTIVE] (tip)
+
+# org/project-b (local)
+local_fix_b [IMPLEMENTING] (tip)
+```
+
+**Testing approach:**
+
+Per TESTING_PHILOSOPHY.md, tests will verify:
+- Grouped output format for each artifact type
+- Per-group causal ordering is preserved
+- External artifact dependents are shown
+- Non-task context behavior unchanged
+- Edge cases: empty external repo, empty projects, mixed scenarios
+
+## Subsystem Considerations
+
+- **docs/subsystems/workflow_artifacts** (STABLE): This chunk IMPLEMENTS an extension to the grouped listing behavior for task contexts. The subsystem currently documents list commands but only covers external repo listing in task context. This chunk extends the behavior to show all locations grouped.
+
+After implementation, the subsystem's OVERVIEW.md should be updated with a new section documenting the grouped listing behavior pattern.
+
+## Sequence
+
+### Step 1: Add grouped listing function to task_utils.py
+
+Create `list_task_artifacts_grouped()` function that:
+- Takes `task_dir` and `artifact_type` parameters
+- Returns a structured result containing:
+  - External repo artifacts with their dependents
+  - Each project's local-only artifacts
+  - Per-group causal ordering via `ArtifactIndex`
+- Uses existing utilities: `load_task_config()`, `resolve_repo_directory()`, `ArtifactIndex`
+
+The function should return a data structure like:
+```python
+{
+    "external": {
+        "repo": "org/external-repo",
+        "artifacts": [
+            {"name": "...", "status": "...", "dependents": [...], "is_tip": bool}
+        ]
+    },
+    "projects": [
+        {
+            "repo": "org/project-a",
+            "artifacts": [
+                {"name": "...", "status": "...", "is_tip": bool}
+            ]
+        }
+    ]
+}
+```
+
+Location: `src/task_utils.py`
+
+### Step 2: Create generic artifact listing helper
+
+Add helper function `_list_artifacts_with_tips()` that:
+- Takes a project path and artifact type
+- Returns list of artifacts with status and tip indicator
+- Filters out external artifacts (those with `external.yaml` pointing elsewhere)
+- Uses the appropriate manager class (Chunks, Narratives, etc.) and `ArtifactIndex`
+
+This helper consolidates common logic across artifact types.
+
+Location: `src/task_utils.py`
+
+### Step 3: Update _list_task_chunks in ve.py
+
+Modify `_list_task_chunks()` to:
+- Call the new `list_task_artifacts_grouped()` instead of `list_task_chunks()`
+- Format output with group headers
+- Show tip indicators
+- Show dependents only for external artifacts
+
+Location: `src/ve.py`
+
+### Step 4: Update _list_task_narratives in ve.py
+
+Apply the same grouped listing pattern to `_list_task_narratives()`.
+
+Location: `src/ve.py`
+
+### Step 5: Update _list_task_investigations in ve.py
+
+Apply the same grouped listing pattern to `_list_task_investigations()`.
+
+Location: `src/ve.py`
+
+### Step 6: Update _list_task_subsystems in ve.py
+
+Apply the same grouped listing pattern to `_list_task_subsystems()`.
+
+Location: `src/ve.py`
+
+### Step 7: Write tests for grouped chunk listing
+
+Create tests in `tests/test_task_chunk_list.py` (extend existing file):
+- Test grouped output format with external and local artifacts
+- Test per-group causal ordering is preserved
+- Test external artifact dependents display
+- Test tip indicators shown correctly
+- Test empty projects handled gracefully
+- Test filtering excludes external references in local listings
+
+Location: `tests/test_task_chunk_list.py`
+
+### Step 8: Write tests for grouped narrative listing
+
+Create tests in `tests/test_task_narrative_list.py` (extend existing file):
+- Same test patterns as chunks
+
+Location: `tests/test_task_narrative_list.py`
+
+### Step 9: Write tests for grouped investigation listing
+
+Create tests in `tests/test_task_investigation_list.py` (extend existing file):
+- Same test patterns as chunks
+
+Location: `tests/test_task_investigation_list.py`
+
+### Step 10: Write tests for grouped subsystem listing
+
+Create tests in `tests/test_task_subsystem_list.py` (extend existing file):
+- Same test patterns as chunks
+
+Location: `tests/test_task_subsystem_list.py`
+
+### Step 11: Update subsystem documentation
+
+Add a new section to `docs/subsystems/workflow_artifacts/OVERVIEW.md` documenting:
+- The grouped listing behavior for task contexts
+- The output format specification
+- The per-group causal ordering preservation
+
+Location: `docs/subsystems/workflow_artifacts/OVERVIEW.md`
+
+---
+
+**BACKREFERENCE COMMENTS**
+
+When implementing code, add backreference comments:
+
+```python
+# Chunk: docs/chunks/task_status_command - Grouped task artifact listing
+```
+
+For the subsystem update:
+```
+# Chunk: docs/chunks/task_status_command - Grouped listing behavior
+# Subsystem: docs/subsystems/workflow_artifacts - Task-aware artifact listing
+```
+
+## Dependencies
+
+- **task_aware_investigations** and **task_aware_subsystem_cmds** chunks must be complete (they are - listed in `created_after`)
+- Existing `list_task_*` functions in `task_utils.py` provide the foundation
+
+## Risks and Open Questions
+
+1. **Performance with many projects**: Loading artifacts from multiple projects might be slow. The `ArtifactIndex` cache should help, but we may need to consider lazy loading if task directories have many participating projects. For now, assume reasonable project counts (< 10).
+
+2. **External artifact detection in local listings**: Need to correctly identify and exclude artifacts that are external references (have `external.yaml` but no main doc) from local listings. The `is_external_artifact()` function handles this.
+
+3. **Empty groups**: Should empty groups (no local artifacts in a project) be shown or hidden? Design choice: Show all projects in the task config even if they have no local artifacts of that type, to provide complete visibility. Can show "(none)" if preferred.
+
+## Deviations
+
+<!--
+POPULATE DURING IMPLEMENTATION, not at planning time.
+-->

--- a/docs/investigations/task_agent_experience/OVERVIEW.md
+++ b/docs/investigations/task_agent_experience/OVERVIEW.md
@@ -8,8 +8,8 @@ proposed_chunks:
     chunk_directory: null
   - prompt: "Add learning philosophy section to project CLAUDE.md template mentioning natural progression to narratives, subsystems, and tasks"
     chunk_directory: null
-  - prompt: "Add ve chunk list --all (or ve task status) showing artifacts grouped by location with per-group causal ordering"
-    chunk_directory: null
+  - prompt: "Enhance artifact list commands to show grouped-by-location output as default in task context (external repo artifacts + each project's local artifacts with per-group causal ordering)"
+    chunk_directory: task_status_command
   - prompt: "Extend SymbolicReference for project-qualified paths (org/repo::path#symbol format) to support task-level code_references across multiple projects"
     chunk_directory: null
 created_after: ["alphabetical_chunk_grouping"]
@@ -470,10 +470,10 @@ ALL commands work from task root. The distinction was wrong.
    - Dependencies: None
    - Notes: Keep this brief. Just a sentence or two in the "Getting Started" or a new "Growing with Vibe Engineering" section.
 
-4. **Add cross-project artifact listing**: Implement `ve chunk list --all` (or `ve task status`) that shows artifacts grouped by location: external repo first, then each project's local artifacts. Each group preserves its own causal ordering.
-   - Priority: Low
+4. **Add cross-project artifact listing**: ~~Implement `ve chunk list --all` (or `ve task status`) that shows artifacts grouped by location~~ **IMPLEMENTED** in chunk `task_status_command`. All artifact list commands (`ve chunk list`, `ve narrative list`, `ve investigation list`, `ve subsystem list`) now show grouped-by-location output in task context: external repo artifacts first (with dependents), then each project's local artifacts. Each group preserves its own causal ordering. Local artifacts that are external references are excluded from the local section.
+   - Priority: ~~Low~~ Done
    - Dependencies: None
-   - Notes: Useful for seeing complete picture across task. Group-by-location design sidesteps the causal ordering ambiguity.
+   - Notes: Implemented as default behavior rather than a separate flag or command.
 
 5. **Extend SymbolicReference for project-qualified paths**: Add support for `org/repo::path#symbol` format in code_references. This enables task-level chunks to have forward references to code in multiple participating projects.
    - Priority: High

--- a/docs/subsystems/workflow_artifacts/OVERVIEW.md
+++ b/docs/subsystems/workflow_artifacts/OVERVIEW.md
@@ -61,6 +61,8 @@ chunks:
   relationship: implements
 - chunk_id: task_aware_subsystem_cmds
   relationship: implements
+- chunk_id: task_status_command
+  relationship: implements
 code_references:
 - ref: src/chunks.py#Chunks
   implements: Chunk workflow manager class
@@ -199,6 +201,15 @@ code_references:
   compliance: COMPLIANT
 - ref: src/ve.py#_list_task_subsystems
   implements: CLI handler for task-aware subsystem listing
+  compliance: COMPLIANT
+- ref: src/task_utils.py#list_task_artifacts_grouped
+  implements: Grouped task artifact listing with external and local sections
+  compliance: COMPLIANT
+- ref: src/task_utils.py#_list_local_artifacts
+  implements: List local artifacts for a project, excluding external references
+  compliance: COMPLIANT
+- ref: src/ve.py#_format_grouped_artifact_list
+  implements: Output formatter for grouped artifact listing
   compliance: COMPLIANT
 proposed_chunks:
 - prompt: Add ChunkStatus StrEnum and ChunkFrontmatter Pydantic model to models.py.


### PR DESCRIPTION
## Summary

Enhances artifact list commands (`ve chunk list`, `ve narrative list`, `ve subsystem list`, `ve investigation list`) to show grouped-by-location output when running from a task context. External repo artifacts appear first with their dependents, followed by each participating project's local artifacts, with per-group causal ordering preserved.

## Implementation

- Added `list_task_artifacts_grouped()` and `_list_local_artifacts()` to `task_utils.py` for collecting and organizing artifacts by location
- Added `_format_grouped_artifact_list()` output formatter to `ve.py` for consistent display across all artifact types
- Updated all `_list_task_*` handlers to use the new grouped listing format
- Comprehensive tests for grouped output across chunks, narratives, investigations, and subsystems
- Updated `workflow_artifacts` subsystem documentation

## Test Plan

- ✅ Grouped output format displays external artifacts with dependents, then local artifacts per project
- ✅ Per-group causal ordering is preserved (newest first within each section)
- ✅ External references are correctly filtered from local listings
- ✅ Tip indicators show correctly for artifacts with no dependents
- ✅ Non-task context behavior remains unchanged
- ✅ All four artifact types (chunks, narratives, investigations, subsystems) work consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)