### PR TITLE
feat: add CLAUDE.md and .claude/commands scaffolding to ve task init

### DIFF
--- a/docs/chunks/future_chunk_creation/GOAL.md
+++ b/docs/chunks/future_chunk_creation/GOAL.md
@@ -7,7 +7,7 @@ code_paths:
 - src/ve.py
 - src/task_utils.py
 - src/templates/chunk/GOAL.md.jinja2
-- src/templates/commands/chunk-create.md
+- src/templates/commands/chunk-create.md.jinja2
 - tests/test_chunks.py
 - tests/test_chunk_start.py
 - tests/test_chunk_list.py
@@ -21,7 +21,7 @@ code_references:
     constraint
 - ref: src/chunks.py#Chunks::create_chunk
   implements: Extended with status parameter to support FUTURE and IMPLEMENTING statuses
-- ref: src/ve.py#start
+- ref: src/ve.py#create
   implements: CLI command with --future flag for creating FUTURE chunks
 - ref: src/ve.py#list_chunks
   implements: CLI command showing status in brackets, --latest uses get_current_chunk
@@ -34,7 +34,7 @@ code_references:
 - ref: src/templates/chunk/GOAL.md.jinja2
   implements: Template with FUTURE status documentation and Jinja status variable
 - ref: src/templates/commands/chunk-create.md.jinja2
-  implements: Skill checks for IMPLEMENTING chunk and defaults to --future
+  implements: Skill with task context conditional and checks for IMPLEMENTING chunk, defaults to --future
 - ref: docs/trunk/SPEC.md
   implements: Specification updated with FUTURE status, --future flag, and ve chunk
     activate

--- a/docs/chunks/task_init/GOAL.md
+++ b/docs/chunks/task_init/GOAL.md
@@ -11,7 +11,7 @@ code_paths:
 - README.md
 code_references:
 - ref: src/task_init.py#TaskInitResult
-  implements: Dataclass for returning init results
+  implements: Dataclass for returning init results (extended by task_init_scaffolding with created_files tracking)
 - ref: src/task_init.py#_resolve_repo_path
   implements: Helper to resolve org/repo format to filesystem path
 - ref: src/task_init.py#TaskInit
@@ -21,13 +21,13 @@ code_references:
 - ref: src/task_init.py#TaskInit::_validate_directory
   implements: Checks existence, git repo, VE-initialized
 - ref: src/task_init.py#TaskInit::execute
-  implements: Creates .ve-task.yaml with TaskConfig schema
+  implements: Creates .ve-task.yaml and coordinates scaffolding (CLAUDE.md and commands added by task_init_scaffolding)
 - ref: src/git_utils.py#is_git_repository
   implements: Helper for git repository validation
 - ref: src/ve.py#task
   implements: Task command group
-- ref: src/ve.py#init
-  implements: task init subcommand
+- ref: src/ve.py#task_init
+  implements: task init subcommand (note - function named 'init' under @task.command decorator)
 - ref: README.md
   implements: Cross-Repository Work documentation section
 narrative: cross_repo_chunks

--- a/docs/chunks/task_init_scaffolding/GOAL.md
+++ b/docs/chunks/task_init_scaffolding/GOAL.md
@@ -1,0 +1,101 @@
+---
+status: ACTIVE
+ticket: null
+parent_chunk: null
+code_paths:
+  - src/task_init.py
+  - tests/test_task_init.py
+  - src/templates/task/CLAUDE.md.jinja2
+  - src/templates/commands/chunk-create.md.jinja2
+  - src/templates/commands/chunk-plan.md.jinja2
+  - src/templates/commands/chunk-implement.md.jinja2
+  - src/templates/commands/chunk-complete.md.jinja2
+  - src/templates/commands/narrative-create.md.jinja2
+  - src/templates/commands/subsystem-discover.md.jinja2
+  - src/templates/commands/investigation-create.md.jinja2
+  - docs/trunk/SPEC.md
+code_references:
+  - ref: src/template_system.py#TaskContext
+    implements: "Task-level context dataclass for template rendering with external_artifact_repo, projects, and task_context flag"
+  - ref: src/task_init.py#TaskInit::_render_claude_md
+    implements: "Renders task CLAUDE.md template to task root"
+  - ref: src/task_init.py#TaskInit::_render_commands
+    implements: "Renders command templates to .claude/commands/ with task context"
+  - ref: src/task_init.py#TaskInitResult
+    implements: "Extended result dataclass with created_files tracking"
+  - ref: src/project.py#Project::_init_commands
+    implements: "Project commands rendered with task_context=False for proper conditional block resolution"
+  - ref: src/templates/task/CLAUDE.md.jinja2
+    implements: "Task-specific CLAUDE.md template with project list and orientation"
+  - ref: src/templates/commands/chunk-create.md.jinja2
+    implements: "Chunk create command with task context conditional block"
+  - ref: src/templates/commands/chunk-implement.md.jinja2
+    implements: "Chunk implement command with task context conditional block"
+  - ref: src/templates/commands/chunk-plan.md.jinja2
+    implements: "Chunk plan command with task context conditional block"
+  - ref: src/templates/commands/chunk-complete.md.jinja2
+    implements: "Chunk complete command with task context conditional block"
+  - ref: src/templates/commands/narrative-create.md.jinja2
+    implements: "Narrative create command with task context conditional block"
+  - ref: src/templates/commands/subsystem-discover.md.jinja2
+    implements: "Subsystem discover command with task context conditional block"
+  - ref: src/templates/commands/investigation-create.md.jinja2
+    implements: "Investigation create command with task context conditional block"
+  - ref: tests/test_task_init.py#TestTaskInitClaudeMd
+    implements: "Tests for CLAUDE.md generation in task init"
+  - ref: tests/test_task_init.py#TestTaskInitCommands
+    implements: "Tests for command template rendering in task init"
+  - ref: tests/test_task_init.py#TestTaskInitCreatedFiles
+    implements: "Tests for created_files tracking in TaskInitResult"
+  - ref: tests/test_template_system.py#TestTaskContext
+    implements: "Tests for TaskContext dataclass"
+  - ref: tests/test_template_system.py#TestConditionalBlocks
+    implements: "Tests for task_context conditional blocks in templates"
+narrative: null
+subsystems:
+  - subsystem_id: template_system
+    relationship: uses
+created_after: ["task_aware_investigations", "task_aware_subsystem_cmds"]
+investigation: docs/investigations/task_agent_experience
+---
+
+# Chunk Goal
+
+## Minor Goal
+
+Enhance `ve task init` to generate Claude Code scaffolding files alongside `.ve-task.yaml`, providing agents with immediate orientation when working in task contexts.
+
+Currently, task directories only receive a `.ve-task.yaml` file, leaving agents without the CLAUDE.md and `.claude/commands/` scaffolding they need to understand the multi-project context and access slash commands. This chunk adds:
+
+1. **CLAUDE.md generation**: A lean (~30 lines) template populated with the task's external repo and project list, providing essential orientation without duplicating workflow details that live in slash commands.
+
+2. **`.claude/commands/` rendering**: Render command Jinja2 templates from `src/templates/commands/` to the task root's `.claude/commands/` with task-aware context. Commands contain conditional Jinja2 blocks (`{% if task_context %}...{% endif %}`) that explain task-specific behavior (e.g., "creates in external repo" vs "creates in this project").
+
+3. **Context-aware command templates**: Update existing command files to include conditional content for task vs project contexts, so agents understand where artifacts will be created and how cross-project workflows differ.
+
+This enables the "same agent experience everywhere" vision—agents in task contexts have the same orientation and command access as agents in project contexts, with guidance tailored to their current context.
+
+## Success Criteria
+
+1. **CLAUDE.md generated**: Running `ve task init --external org/repo --project org/project-a --project org/project-b` creates a `CLAUDE.md` file in the task directory with:
+   - External artifact repo reference populated from `--external`
+   - Project list populated from `--project` arguments
+   - Essential orientation content (~30 lines) rendered from new `src/templates/task/CLAUDE.md.jinja2`
+
+2. **`.claude/commands/` rendered**: Command templates from `src/templates/commands/` are rendered to the task root with task context:
+   - Template variables: `task_context=True`, `external_artifact_repo`, `projects`
+   - Conditional blocks (`{% if task_context %}...{% else %}...{% endif %}`) render task-specific content
+   - All command templates are rendered to task root's `.claude/commands/`
+
+3. **Command templates updated**: Existing command files include conditional content:
+   - `/chunk-create`: Explains artifact creation in external repo with external.yaml references
+   - `/chunk-implement`: Notes implementation spans participating projects
+   - Other artifact commands: Similar context-aware guidance
+   - Project context (no task_context): Commands work as before
+
+4. **Existing project .claude/commands/ regenerated**: After adding conditional blocks to command templates, regenerate the project's `.claude/commands/` with `task_context=False` to maintain current behavior for project contexts
+
+5. **Idempotent**: Running `ve task init` when scaffolding already exists fails with appropriate error (existing behavior for `.ve-task.yaml` already handles this)
+
+6. **Tests pass**: Unit tests cover CLAUDE.md generation, command template rendering, and conditional block processing
+

--- a/docs/chunks/task_init_scaffolding/PLAN.md
+++ b/docs/chunks/task_init_scaffolding/PLAN.md
@@ -1,0 +1,224 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+This chunk enhances `ve task init` to generate Claude Code scaffolding files alongside `.ve-task.yaml`. The approach follows the existing patterns in the codebase:
+
+1. **Create a new task CLAUDE.md template** (`src/templates/task/CLAUDE.md.jinja2`) based on the lean prototype from the investigation (~30 lines). This template uses Jinja2 variables `external_artifact_repo` and `projects` to render task-specific content.
+
+2. **Add conditional blocks to command templates** using Jinja2's `{% if task_context %}...{% else %}...{% endif %}` pattern. This allows the same templates to serve both project and task contexts with appropriate guidance.
+
+3. **Extend TaskInit to render scaffolding** by adding new methods to generate CLAUDE.md and render `.claude/commands/` from templates, following the same patterns used in `src/project.py`.
+
+4. **Create a TaskContext dataclass** in `template_system.py` to provide task-specific template context, analogous to how `TemplateContext` works for project contexts.
+
+The implementation leverages the established template_system subsystem (STABLE status), which provides `render_template`, `render_to_directory`, and related utilities.
+
+Per DEC-004 (markdown references relative to project root), file paths in documentation are relative to project root.
+
+## Subsystem Considerations
+
+- **docs/subsystems/template_system** (STABLE): This chunk USES the template subsystem's established patterns:
+  - `render_template()` and `render_to_directory()` for template rendering
+  - `.jinja2` suffix convention for template files
+  - Template collections organized in `src/templates/{collection}/`
+
+  Since the subsystem is STABLE, we follow its patterns exactly without attempting modifications.
+
+## Sequence
+
+### Step 1: Create task CLAUDE.md template
+
+Create `src/templates/task/CLAUDE.md.jinja2` based on the lean prototype from `docs/investigations/task_agent_experience/prototypes/CLAUDE.md.lean.template`.
+
+The template should:
+- Use Jinja2 syntax (not Mustache as in prototype)
+- Accept `external_artifact_repo` (string) and `projects` (list of strings)
+- Be approximately 30 lines
+- Provide essential orientation: project list, where commands work, navigation basics
+- Defer detailed workflow guidance to slash commands
+
+Location: `src/templates/task/CLAUDE.md.jinja2`
+
+### Step 2: Add TaskContext dataclass to template_system
+
+Extend `src/template_system.py` with a `TaskContext` dataclass to hold task-specific template context:
+
+```python
+@dataclass
+class TaskContext:
+    """Holds task-level context for template rendering."""
+    external_artifact_repo: str
+    projects: list[str]
+    task_context: bool = True  # Flag for conditional blocks in templates
+
+    def as_dict(self) -> dict:
+        """Return context as dict suitable for Jinja2 rendering."""
+        return {
+            "external_artifact_repo": self.external_artifact_repo,
+            "projects": self.projects,
+            "task_context": self.task_context,
+        }
+```
+
+This follows the pattern of existing `TemplateContext` but serves task contexts.
+
+Location: `src/template_system.py`
+
+### Step 3: Add conditional blocks to command templates
+
+Update command templates to include task-aware content using Jinja2 conditionals:
+
+For `/chunk-create` (`src/templates/commands/chunk-create.md.jinja2`):
+- Add explanation that in task context, artifacts are created in the external repo
+- Note that external.yaml references are created in participating projects
+
+For `/chunk-implement` (`src/templates/commands/chunk-implement.md.jinja2`):
+- Add note that implementation may span multiple participating projects in task context
+
+For `/chunk-plan` (`src/templates/commands/chunk-plan.md.jinja2`):
+- Works from task root, PLAN.md created in external repo's chunk directory
+
+For `/chunk-complete` (`src/templates/commands/chunk-complete.md.jinja2`):
+- Note about collecting code_references from all participating projects in task context
+
+For `/narrative-create`, `/subsystem-discover`, `/investigation-create`:
+- Similar pattern: artifacts created in external repo in task context
+
+Use the pattern:
+```jinja2
+{% if task_context %}
+**Task Context:** This command creates artifacts in the external artifact repo
+(`{{ external_artifact_repo }}`). External references will be created in
+participating projects.
+{% endif %}
+```
+
+Locations: All files in `src/templates/commands/`
+
+### Step 4: Extend TaskInit with scaffolding generation
+
+Add methods to `src/task_init.py`:
+
+1. `_render_claude_md()` - Renders the task CLAUDE.md template to task root
+2. `_render_commands()` - Renders command templates to `.claude/commands/` with task context
+
+Modify `execute()` to call these new methods after creating `.ve-task.yaml`.
+
+The implementation should:
+- Import `render_template`, `render_to_directory`, and `TaskContext` from `template_system`
+- Create `TaskContext` with config values
+- Render templates with task context (task_context=True)
+
+Location: `src/task_init.py`
+
+### Step 5: Update TaskInitResult
+
+Extend `TaskInitResult` dataclass to include information about scaffolding files:
+
+```python
+@dataclass
+class TaskInitResult:
+    config_path: Path
+    external_repo: str
+    projects: list[str]
+    created_files: list[str] = field(default_factory=list)  # New
+```
+
+Location: `src/task_init.py`
+
+### Step 6: Regenerate project .claude/commands/ with task_context=False
+
+To ensure existing projects get commands with the conditional blocks resolved for project context, we need to ensure `ve init` renders commands with `task_context=False`.
+
+Modify `src/project.py#_init_commands()` to pass `task_context=False` when rendering:
+
+```python
+render_result = render_to_directory(
+    "commands", commands_dir, context=context, overwrite=True, task_context=False
+)
+```
+
+This ensures the project-context versions don't have any `{% if task_context %}` remnants.
+
+Location: `src/project.py`
+
+### Step 7: Write tests for CLAUDE.md generation
+
+Create test cases verifying:
+- `ve task init` creates CLAUDE.md in task directory
+- CLAUDE.md contains external_artifact_repo from config
+- CLAUDE.md contains project list from config
+- Content is rendered from template (not a copy of template source)
+
+Follow TDD: write failing tests first, then implement.
+
+Location: `tests/test_task_init.py`
+
+### Step 8: Write tests for command rendering
+
+Create test cases verifying:
+- `ve task init` creates `.claude/commands/` directory
+- All command templates are rendered (chunk-create.md, etc.)
+- Commands contain task-context specific content (conditional blocks resolved)
+- Commands reference external_artifact_repo from config
+
+Follow TDD: write failing tests first, then implement.
+
+Location: `tests/test_task_init.py`
+
+### Step 9: Write tests for conditional block processing
+
+Create test cases verifying:
+- In task context: task-specific content is present
+- In project context: task-specific content is absent
+- Templates render without errors in both contexts
+
+This may require a new test file or additions to existing template tests.
+
+Location: `tests/test_template_system.py` or `tests/test_task_init.py`
+
+### Step 10: Run tests and update SPEC.md
+
+1. Run full test suite: `uv run pytest tests/`
+2. Fix any failures
+3. Update `docs/trunk/SPEC.md` to document:
+   - Task directory structure now includes CLAUDE.md and `.claude/commands/`
+   - `ve task init` postconditions include scaffolding file creation
+
+---
+
+**BACKREFERENCE COMMENTS**
+
+When implementing code, add backreference comments:
+
+```python
+# Chunk: docs/chunks/task_init_scaffolding - Task CLAUDE.md and commands scaffolding
+# Subsystem: docs/subsystems/template_system - Uses template rendering
+```
+
+## Dependencies
+
+- **template_system subsystem (STABLE)**: Required for `render_template`, `render_to_directory`, and template collection patterns
+- **Existing command templates**: Templates in `src/templates/commands/` that will receive conditional blocks
+- **task_init.py**: The existing TaskInit class that will be extended
+
+## Risks and Open Questions
+
+1. **Conditional block syntax in rendered output**: When rendering commands for project context (`task_context=False`), Jinja2 should completely omit the conditional blocks. Need to verify the templates render cleanly in both contexts.
+
+2. **Template variable availability**: Command templates currently render with `TemplateContext` which has project-level context. Need to ensure `task_context` variable is available even when not in task mode (as `False` or undefined).
+
+3. **Idempotency of scaffolding creation**: The current `ve task init` fails if `.ve-task.yaml` exists. The new scaffolding generation should follow the same pattern (fail if already exists rather than silently overwrite).
+
+4. **Test helper reuse**: Per TESTING_PHILOSOPHY.md, should check `conftest.py` for existing helpers before creating new ones. The `setup_task_directory` helper already exists and should be extended rather than duplicated.
+
+## Deviations
+
+<!-- Populate during implementation -->

--- a/docs/investigations/task_agent_experience/OVERVIEW.md
+++ b/docs/investigations/task_agent_experience/OVERVIEW.md
@@ -3,9 +3,9 @@ status: ONGOING
 trigger: "Task directories lack Claude Code scaffolding (CLAUDE.md, .claude/commands) for effective agent experience"
 proposed_chunks:
   - prompt: "Modify ve task init to generate a lean CLAUDE.md (~30 lines) from template with external_artifact_repo and projects list - orientation only, defer details to slash commands"
-    chunk_directory: null
+    chunk_directory: task_init_scaffolding
   - prompt: "During ve task init, setup .claude/commands in task directory (symlink or copy from external repo)"
-    chunk_directory: null
+    chunk_directory: task_init_scaffolding
   - prompt: "Add learning philosophy section to project CLAUDE.md template mentioning natural progression to narratives, subsystems, and tasks"
     chunk_directory: null
   - prompt: "Add ve chunk list --all (or ve task status) showing artifacts grouped by location with per-group causal ordering"

--- a/src/project.py
+++ b/src/project.py
@@ -56,19 +56,27 @@ class Project:
 
     # Chunk: docs/chunks/project_init_command - Claude commands initialization
     # Chunk: docs/chunks/template_system_consolidation - Template system integration
+    # Chunk: docs/chunks/task_init_scaffolding - task_context=False for project context
     # Subsystem: docs/subsystems/template_system - Uses render_to_directory
     def _init_commands(self) -> InitResult:
         """Set up Claude commands by rendering templates.
 
         Commands are always updated to the latest templates (overwrite=True)
         because they are managed artifacts, not user content.
+
+        Commands are rendered with task_context=False to ensure the conditional
+        blocks for task-specific content are properly omitted in project context.
         """
         result = InitResult()
         commands_dir = self.project_dir / ".claude" / "commands"
 
         # Use render_to_directory with overwrite=True to always update commands
+        # Pass task_context=False to ensure project-context commands don't include
+        # task-specific conditional content
         context = TemplateContext()
-        render_result = render_to_directory("commands", commands_dir, context=context, overwrite=True)
+        render_result = render_to_directory(
+            "commands", commands_dir, context=context, overwrite=True, task_context=False
+        )
 
         # Map RenderResult paths to relative path strings for InitResult
         for path in render_result.created:

--- a/src/template_system.py
+++ b/src/template_system.py
@@ -95,6 +95,29 @@ class ActiveInvestigation:
         return self._project_dir / "docs" / "investigations" / self.id / "OVERVIEW.md"
 
 
+# Chunk: docs/chunks/task_init_scaffolding - Task context for template rendering
+# Subsystem: docs/subsystems/template_system - Unified template rendering
+@dataclass
+class TaskContext:
+    """Holds task-level context for template rendering.
+
+    Used when rendering templates in a task directory context, where artifacts
+    are created in an external repo and implementation spans multiple projects.
+    """
+
+    external_artifact_repo: str
+    projects: list[str]
+    task_context: bool = True  # Flag for conditional blocks in templates
+
+    def as_dict(self) -> dict:
+        """Return context as dict suitable for Jinja2 rendering."""
+        return {
+            "external_artifact_repo": self.external_artifact_repo,
+            "projects": self.projects,
+            "task_context": self.task_context,
+        }
+
+
 # Chunk: docs/chunks/canonical_template_module - Unified template context holder
 # Subsystem: docs/subsystems/template_system - Unified template rendering
 @dataclass

--- a/src/templates/commands/chunk-complete.md.jinja2
+++ b/src/templates/commands/chunk-complete.md.jinja2
@@ -5,6 +5,17 @@ description: Update code references in the current chunk and move both the PLAN.
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** When collecting code_references, search across all participating
+projects:
+{% for project in projects %}
+- `{{ project }}`
+{% endfor %}
+
+References should use project-relative paths. The chunk GOAL.md is updated in the
+external artifact repo (`{{ external_artifact_repo }}`).
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/commands/chunk-create.md.jinja2
+++ b/src/templates/commands/chunk-create.md.jinja2
@@ -5,6 +5,13 @@ description: Create a new chunk of work and refine its goal.
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** This command creates artifacts in the external artifact repo
+(`{{ external_artifact_repo }}`). The chunk GOAL.md and PLAN.md will be created
+there. When implementing, code changes happen in participating projects, and
+external.yaml references allow projects to discover the external chunk.
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/commands/chunk-implement.md.jinja2
+++ b/src/templates/commands/chunk-implement.md.jinja2
@@ -5,6 +5,16 @@ description: Implement the active chunk.
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** Implementation may span multiple participating projects:
+{% for project in projects %}
+- `{{ project }}`
+{% endfor %}
+
+The chunk plan is in the external repo (`{{ external_artifact_repo }}`). Work
+from the task root to access both the plan and all project directories.
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/commands/chunk-plan.md.jinja2
+++ b/src/templates/commands/chunk-plan.md.jinja2
@@ -5,6 +5,12 @@ description: Create a chunk PLAN.md file containing the technical breakdown for 
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** The PLAN.md is created in the external artifact repo
+(`{{ external_artifact_repo }}`). When planning, consider how implementation
+will span participating projects and reference their structures appropriately.
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/commands/investigation-create.md.jinja2
+++ b/src/templates/commands/investigation-create.md.jinja2
@@ -5,6 +5,12 @@ description: Start a new investigation or redirect to a simpler chunk workflow.
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** This command creates artifacts in the external artifact repo
+(`{{ external_artifact_repo }}`). The investigation OVERVIEW.md will be created
+there. Exploration may span all participating projects.
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/commands/narrative-create.md.jinja2
+++ b/src/templates/commands/narrative-create.md.jinja2
@@ -5,6 +5,12 @@ description: Collaboratively refine a high-level ambition into a set of chunk pr
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** This command creates artifacts in the external artifact repo
+(`{{ external_artifact_repo }}`). The narrative OVERVIEW.md will be created there.
+Proposed chunks from this narrative will span participating projects.
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/commands/subsystem-discover.md.jinja2
+++ b/src/templates/commands/subsystem-discover.md.jinja2
@@ -5,6 +5,12 @@ description: Guide collaborative discovery of an emergent subsystem.
 ## Tips
 
 {% include "partials/common-tips.md.jinja2" %}
+{% if task_context %}
+
+**Task Context:** This command creates artifacts in the external artifact repo
+(`{{ external_artifact_repo }}`). The subsystem OVERVIEW.md will be created there.
+When discovering patterns, search across all participating projects.
+{% endif %}
 
 ## Instructions
 

--- a/src/templates/task/CLAUDE.md.jinja2
+++ b/src/templates/task/CLAUDE.md.jinja2
@@ -1,0 +1,33 @@
+# Multi-Project Task
+
+You're in a **task directory** coordinating work across multiple repositories.
+
+## Projects
+
+| Role | Repository |
+|------|------------|
+| **External Artifacts** | `{{ external_artifact_repo }}` |
+{% for project in projects %}
+| Participating | `{{ project }}` |
+{% endfor %}
+
+Workflow artifacts (chunks, narratives, subsystems, investigations) live in the external repo. Implementation happens in participating projects.
+
+## Commands
+
+All commands work from task root. You can also `cd` into a project for project-specific work.
+
+**Artifact commands:** `/chunk-create`, `/chunk-plan`, `/chunk-implement`, `/chunk-complete`
+
+**Other artifacts:** `/narrative-create`, `/subsystem-discover`, `/investigation-create`
+
+Run `ve chunk list` to see task-level chunks. Use `/help` for detailed command guidance.
+
+## Backreferences
+
+When implementing, add backreferences to the **project-local** path:
+```python
+# Chunk: docs/chunks/<chunk_name>
+```
+
+This points to the project's external.yaml, which resolves to the external repo.


### PR DESCRIPTION
## Summary

Enhance `ve task init` to generate Claude Code scaffolding files alongside `.ve-task.yaml`, providing agents with immediate orientation in task contexts. This implements the "same agent experience everywhere" vision - agents in task contexts now have the same orientation and command access as agents in project contexts, with guidance tailored to their current context.

## Key Changes

- Add `TaskContext` dataclass for task-level template rendering with external repo and projects list
- Add `.claude/commands/` rendering with task-context conditional blocks to guide agents appropriately
- Create lean task CLAUDE.md template (~30 lines) providing essential orientation
- Update command templates with `{% if task_context %}` blocks explaining artifact locations
- Ensure project commands render with `task_context=False` to maintain current behavior
- Add comprehensive tests for CLAUDE.md generation, command rendering, and conditional block processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)