### PR TITLE
feat: add project-qualified symbolic references

### DIFF
--- a/docs/chunks/project_qualified_refs/GOAL.md
+++ b/docs/chunks/project_qualified_refs/GOAL.md
@@ -1,0 +1,164 @@
+---
+status: IMPLEMENTING
+ticket: null
+parent_chunk: null
+code_paths: ["src/symbols.py", "src/models.py", "src/chunks.py", "src/subsystems.py", "tests/test_symbols.py", "tests/test_models.py"]
+code_references:
+  - ref: src/symbols.py#parse_reference
+    implements: "Extended parsing to return 3-tuple (project, file_path, symbol_path) with project qualification support"
+  - ref: src/symbols.py#qualify_ref
+    implements: "New function to ensure refs are project-qualified before comparison"
+  - ref: src/symbols.py#is_parent_of
+    implements: "Extended to compare projects first, different projects never overlap"
+  - ref: src/models.py#SymbolicReference::validate_ref
+    implements: "Extended validation to accept org/repo::path format using _require_valid_repo_ref"
+  - ref: src/chunks.py#compute_symbolic_overlap
+    implements: "Updated to qualify refs with project context before comparison"
+  - ref: src/chunks.py#Chunks::_validate_symbol_exists
+    implements: "Updated to qualify refs before parsing"
+  - ref: src/chunks.py#Chunks::find_overlapping_chunks
+    implements: "Updated to use local project context for ref qualification"
+  - ref: src/subsystems.py#Subsystems::_find_overlapping_refs
+    implements: "Updated to qualify refs before comparison"
+  - ref: tests/test_symbols.py#TestParseReferenceWithProjectQualification
+    implements: "Unit tests for project-qualified reference parsing"
+  - ref: tests/test_symbols.py#TestIsParentOfWithProjectContext
+    implements: "Unit tests for is_parent_of with project context"
+  - ref: tests/test_symbols.py#TestOverlapDetectionAcrossProjects
+    implements: "Integration tests for overlap detection across projects"
+  - ref: tests/test_models.py#TestSymbolicReferenceWithProjectQualification
+    implements: "Unit tests for SymbolicReference validation with project qualification"
+narrative: null
+subsystems: []
+created_after: ["task_aware_investigations", "task_aware_subsystem_cmds"]
+---
+
+<!--
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  DO NOT DELETE THIS COMMENT BLOCK until the chunk complete command is run.   ║
+║                                                                              ║
+║  AGENT INSTRUCTIONS: When editing this file, preserve this entire comment    ║
+║  block. Only modify the frontmatter YAML and the content sections below      ║
+║  (Minor Goal, Success Criteria, Relationship to Parent). Use targeted edits  ║
+║  that replace specific sections rather than rewriting the entire file.       ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+
+This comment describes schema information that needs to be adhered
+to throughout the process.
+
+STATUS VALUES:
+- FUTURE: This chunk is queued for future work and not yet being implemented
+- IMPLEMENTING: This chunk is in the process of being implemented.
+- ACTIVE: This chunk accurately describes current or recently-merged work
+- SUPERSEDED: Another chunk has modified the code this chunk governed
+- HISTORICAL: Significant drift; kept for archaeology only
+
+PARENT_CHUNK:
+- null for new work
+- chunk directory name (e.g., "006-segment-compaction") for corrections or modifications
+
+CODE_PATHS:
+- Populated at planning time
+- List files you expect to create or modify
+- Example: ["src/segment/writer.rs", "src/segment/format.rs"]
+
+CODE_REFERENCES:
+- Populated after implementation, before PR
+- Uses symbolic references to identify code locations
+- Format: {file_path}#{symbol_path} where symbol_path uses :: as nesting separator
+- Example:
+  code_references:
+    - ref: src/segment/writer.rs#SegmentWriter
+      implements: "Core write loop and buffer management"
+    - ref: src/segment/writer.rs#SegmentWriter::fsync
+      implements: "Durability guarantees"
+    - ref: src/utils.py#validate_input
+      implements: "Input validation logic"
+
+NARRATIVE:
+- If this chunk was derived from a narrative document, reference the narrative directory name.
+- When setting this field during /chunk-create, also update the narrative's OVERVIEW.md
+  frontmatter to add this chunk to its `chunks` array with the prompt and chunk_directory.
+- If this is the final chunk of a narrative, the narrative status should be set to completed 
+  when this chunk is completed. 
+
+SUBSYSTEMS:
+- Optional list of subsystem references that this chunk relates to
+- Format: subsystem_id is {NNNN}-{short_name}, relationship is "implements" or "uses"
+- "implements": This chunk directly implements part of the subsystem's functionality
+- "uses": This chunk depends on or uses the subsystem's functionality
+- Example:
+  subsystems:
+    - subsystem_id: "0001-validation"
+      relationship: implements
+    - subsystem_id: "0002-frontmatter"
+      relationship: uses
+- Validated by `ve chunk validate` to ensure referenced subsystems exist
+- When a chunk that implements a subsystem is completed, a reference should be added to
+  that chunk in the subsystems OVERVIEW.md file front matter and relevant section.
+
+CHUNK ARTIFACTS:
+- Single-use scripts, migration tools, or one-time utilities created for this chunk
+  should be stored in the chunk directory (e.g., docs/chunks/0042-foo/migrate.py)
+- These artifacts help future archaeologists understand what the chunk did
+- Unlike code in src/, chunk artifacts are not expected to be maintained long-term
+- Examples: data migration scripts, one-time fixups, analysis tools used during implementation
+-->
+
+# Chunk Goal
+
+## Minor Goal
+
+Extend the `SymbolicReference` model to support project-qualified paths using the format `org/repo::path#symbol`. This enables task-level chunks (stored in an external artifact repo) to have forward code references pointing to code in multiple participating projects.
+
+Currently, `SymbolicReference` only supports local file paths like `src/foo.py#FooClass`. When working in a task context that spans multiple repositories, chunk completion (`/chunk-complete`) needs to collect code references from ALL participating projects and store them with project qualification so readers know which project each reference belongs to.
+
+This directly supports the project goal of enabling multi-project workflows. Without project-qualified references, task-level chunks cannot properly document which code they touch across repositories, breaking the bidirectional traceability between docs and code.
+
+## Success Criteria
+
+### Extended Reference Format
+
+- `SymbolicReference.ref` accepts project-qualified paths: `org/repo::path#symbol`
+- The `::` delimiter separates the project qualifier from the file path
+- Valid examples:
+  - `acme/project-a::src/foo.py#FooClass` (class in project-a)
+  - `acme/project-b::src/bar.py#BarClass::method` (method in project-b)
+  - `acme/shared-lib::lib/utils.py` (entire module in shared-lib)
+- Non-qualified paths remain valid for single-project (local) use:
+  - `src/foo.py#FooClass` (local reference, no project qualifier)
+
+### Validation Rules
+
+- Project qualifier must be valid `org/repo` format (validated via existing `_require_valid_repo_ref`)
+- File path after `::` follows existing validation rules
+- Symbol path after `#` follows existing validation rules
+- At most one `::` allowed (project delimiter)
+- At most one `#` allowed (symbol delimiter)
+- Order must be: `[org/repo::]file_path[#symbol_path]`
+
+### Parsing Support
+
+- Extend `parse_reference` in `symbols.py` to handle project qualification:
+  - Add optional `current_project: str | None` parameter
+  - Return `(project, file_path, symbol_path)` tuple (breaking change from current 2-tuple)
+  - When reference has no `::` qualifier, use `current_project` as the project
+  - When `current_project` is None and no qualifier present, project is None (local context)
+- Update all call sites of `parse_reference` to handle the new return type
+- The `is_parent_of` function should also accept `current_project` and use fully-qualified references for comparison
+
+### Overlap Detection
+
+- By inferring the current project, all parsed references become fully qualified
+- Overlap detection compares fully-qualified references: same project + hierarchical containment
+- `acme/proj::src/foo.py#Bar` and `src/foo.py#Bar` (with `current_project="acme/proj"`) correctly detect as overlapping
+- References from different projects never overlap, even with identical file paths and symbols
+
+### Test Coverage
+
+- Unit tests for valid project-qualified references
+- Unit tests for invalid formats (multiple `::`, wrong order, etc.)
+- Tests for parsing with `current_project` inference
+- Tests for overlap detection across project-qualified references
+- Tests for backward compatibility with non-qualified (local) references
+

--- a/docs/chunks/project_qualified_refs/PLAN.md
+++ b/docs/chunks/project_qualified_refs/PLAN.md
@@ -1,0 +1,134 @@
+<!--
+This document captures HOW you'll achieve the chunk's GOAL.
+It should be specific enough that each step is a reasonable unit of work
+to hand to an agent.
+-->
+
+# Implementation Plan
+
+## Approach
+
+This chunk extends `SymbolicReference` and `parse_reference` to support project-qualified paths in the format `org/repo::path#symbol`. The approach builds on existing code:
+
+1. **Extend `parse_reference`** in `src/symbols.py` to return a 3-tuple `(project, file_path, symbol_path)` instead of the current 2-tuple. The `::` delimiter separates the project qualifier from the file path.
+
+2. **Update all call sites** of `parse_reference` to handle the new return type. Call sites in `src/chunks.py` and `src/subsystems.py` will pass `current_project=None` (local context) to maintain backward compatibility.
+
+3. **Extend `is_parent_of`** to compare fully-qualified references. When both references have the same project (including both `None`), the existing hierarchical comparison applies. References from different projects never overlap.
+
+4. **Extend `SymbolicReference` validation** in `src/models.py` to accept the `org/repo::path` format, reusing `_require_valid_repo_ref` for the project qualifier validation.
+
+5. **Follow TDD** per `docs/trunk/TESTING_PHILOSOPHY.md`: Write failing tests first, then implementation.
+
+This aligns with DEC-002 (git not assumed) by enabling references to span multiple repositories in a task context.
+
+## Subsystem Considerations
+
+No subsystems are directly relevant to this chunk. The `template_system` and `workflow_artifacts` subsystems documented in `docs/subsystems/` are not touched by this work, which focuses on the symbol parsing and reference validation layer.
+
+## Sequence
+
+### Step 1: Write failing tests for `parse_reference` with project qualification
+
+Add tests to `tests/test_symbols.py` that verify:
+- `parse_reference("acme/proj::src/foo.py")` returns `("acme/proj", "src/foo.py", None)`
+- `parse_reference("acme/proj::src/foo.py#Bar")` returns `("acme/proj", "src/foo.py", "Bar")`
+- `parse_reference("acme/proj::src/foo.py#Bar::baz")` returns `("acme/proj", "src/foo.py", "Bar::baz")`
+- `parse_reference("src/foo.py#Bar")` returns `(None, "src/foo.py", "Bar")` (backward compatible)
+- `parse_reference("src/foo.py#Bar", current_project="acme/proj")` returns `("acme/proj", "src/foo.py", "Bar")`
+
+Also test error cases:
+- Multiple `::` delimiters should be invalid
+- Empty project qualifier (`::src/foo.py`) should be invalid
+
+Location: `tests/test_symbols.py`
+
+### Step 2: Implement extended `parse_reference`
+
+Update `parse_reference` in `src/symbols.py` to:
+- Accept optional `current_project: str | None` parameter
+- Return 3-tuple `(project, file_path, symbol_path)`
+- Parse `::` delimiter for project qualification
+- Use `current_project` when no explicit qualifier present
+
+Location: `src/symbols.py`
+
+### Step 3: Write failing tests for `is_parent_of` with project context
+
+Add tests to verify:
+- Same project + hierarchical relationship → True
+- Different projects + same file path → False (never overlap across projects)
+- Both None projects + hierarchical relationship → True (backward compatible)
+- `is_parent_of("acme/proj::src/foo.py#Bar", "acme/proj::src/foo.py#Bar::baz")` → True
+- `is_parent_of("acme/a::src/foo.py#Bar", "acme/b::src/foo.py#Bar")` → False
+
+Location: `tests/test_symbols.py`
+
+### Step 4: Extend `is_parent_of` for project-qualified references
+
+Update `is_parent_of` in `src/symbols.py` to:
+- Accept optional `current_project: str | None` parameter
+- Parse both references with project context
+- Return False immediately if projects differ
+- Apply existing hierarchical logic when projects match
+
+Location: `src/symbols.py`
+
+### Step 5: Write failing tests for `SymbolicReference` with project qualification
+
+Add tests to `tests/test_models.py` that verify:
+- `SymbolicReference(ref="acme/proj::src/foo.py#Bar", implements="...")` validates successfully
+- `SymbolicReference(ref="acme/proj::src/foo.py", implements="...")` validates (file-only)
+- Invalid formats are rejected: `"::src/foo.py"`, `"acme::::src/foo.py"`, `"acme/proj::src/foo.py#Bar#baz"`
+- Backward compatible: `SymbolicReference(ref="src/foo.py#Bar", implements="...")` still works
+
+Location: `tests/test_models.py`
+
+### Step 6: Extend `SymbolicReference.validate_ref` for project qualification
+
+Update the `validate_ref` validator in `src/models.py` to:
+- Check for at most one `::` delimiter
+- If `::` present, validate project portion using `_require_valid_repo_ref`
+- Validate file path and symbol portions with existing rules
+- Maintain backward compatibility for non-qualified references
+
+Location: `src/models.py`
+
+### Step 7: Update call sites of `parse_reference`
+
+Update all call sites to handle the new 3-tuple return:
+- `src/chunks.py`: `_validate_symbol_exists`, `find_overlapping_chunks`
+- `src/subsystems.py`: `_find_overlapping_refs`
+
+Pass `current_project=None` to maintain local behavior. The tuple unpacking changes from `(file_path, symbol_path)` to `(_, file_path, symbol_path)` where the project is ignored in local context.
+
+Locations: `src/chunks.py`, `src/subsystems.py`
+
+### Step 8: Write integration tests for overlap detection across projects
+
+Add tests verifying:
+- Two refs from same project correctly detect overlap
+- Two refs from different projects never overlap, even with identical file+symbol
+- Mixed qualified and unqualified refs (with `current_project`) detect overlap correctly
+
+Location: `tests/test_symbols.py` or `tests/test_chunks.py`
+
+### Step 9: Run full test suite and fix any regressions
+
+Execute `uv run pytest tests/` and address any failures. Verify backward compatibility for all existing tests.
+
+## Dependencies
+
+No external dependencies. This builds on existing validation utilities (`_require_valid_repo_ref` in `src/models.py`) and the current `parse_reference` / `is_parent_of` functions in `src/symbols.py`.
+
+## Risks and Open Questions
+
+1. **Breaking change to `parse_reference` return type**: Changing from 2-tuple to 3-tuple is a breaking change. All call sites must be updated simultaneously. The plan handles this in Step 7.
+
+2. **Validation strictness for project qualifier**: The goal says to validate via `_require_valid_repo_ref`, but that function raises `ValueError` on invalid input. Need to decide whether `parse_reference` should raise or return an error indicator. Current approach: `parse_reference` does not validate—it just parses. Validation happens in `SymbolicReference.validate_ref`.
+
+3. **Edge case: `::` in file paths**: Windows paths don't use `::`, and Unix paths never contain it, so this delimiter choice is safe. No risk identified.
+
+## Deviations
+
+<!-- Populated during implementation -->

--- a/docs/investigations/task_agent_experience/OVERVIEW.md
+++ b/docs/investigations/task_agent_experience/OVERVIEW.md
@@ -11,7 +11,7 @@ proposed_chunks:
   - prompt: "Add ve chunk list --all (or ve task status) showing artifacts grouped by location with per-group causal ordering"
     chunk_directory: null
   - prompt: "Extend SymbolicReference for project-qualified paths (org/repo::path#symbol format) to support task-level code_references across multiple projects"
-    chunk_directory: null
+    chunk_directory: project_qualified_refs
 created_after: ["alphabetical_chunk_grouping"]
 ---
 

--- a/src/subsystems.py
+++ b/src/subsystems.py
@@ -19,7 +19,7 @@ import yaml
 
 from artifact_ordering import ArtifactIndex, ArtifactType
 from models import SubsystemFrontmatter, SubsystemStatus, VALID_STATUS_TRANSITIONS, extract_short_name
-from symbols import is_parent_of, parse_reference
+from symbols import is_parent_of, parse_reference, qualify_ref
 from template_system import ActiveSubsystem, TemplateContext, render_to_directory
 
 if TYPE_CHECKING:
@@ -419,6 +419,7 @@ class Subsystems:
         return results
 
     # Chunk: docs/chunks/subsystem_impact_resolution - Compute reference overlap
+    # Chunk: docs/chunks/project_qualified_refs - Qualify refs before comparison
     def _find_overlapping_refs(
         self, chunk_refs: list[str], subsystem_refs: list[str]
     ) -> list[str]:
@@ -432,11 +433,14 @@ class Subsystems:
             List of subsystem reference strings that overlap.
         """
         overlapping: list[str] = []
+        local_project = "."
 
         for subsystem_ref in subsystem_refs:
+            qualified_subsystem = qualify_ref(subsystem_ref, local_project)
             for chunk_ref in chunk_refs:
+                qualified_chunk = qualify_ref(chunk_ref, local_project)
                 # Check both directions: chunk->subsystem and subsystem->chunk
-                if is_parent_of(chunk_ref, subsystem_ref) or is_parent_of(subsystem_ref, chunk_ref):
+                if is_parent_of(qualified_chunk, qualified_subsystem) or is_parent_of(qualified_subsystem, qualified_chunk):
                     overlapping.append(subsystem_ref)
                     break  # Don't add the same ref multiple times
 

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -375,67 +375,67 @@ class TestSymbolicOverlap:
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py"]
         refs_b = ["src/foo.py"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is True
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is True
 
     def test_parent_contains_child(self):
         """foo.py#Bar and foo.py#Bar::baz overlap (parent contains child)."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py#Bar"]
         refs_b = ["src/foo.py#Bar::baz"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is True
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is True
 
     def test_child_overlaps_with_parent(self):
         """Child also overlaps with parent (symmetric)."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py#Bar::baz"]
         refs_b = ["src/foo.py#Bar"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is True
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is True
 
     def test_different_symbols_same_file_no_overlap(self):
         """foo.py#Bar and foo.py#Qux do not overlap (different symbols)."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py#Bar"]
         refs_b = ["src/foo.py#Qux"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is False
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is False
 
     def test_file_reference_overlaps_any_symbol(self):
         """foo.py (whole module) overlaps with any symbol in that module."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py"]
         refs_b = ["src/foo.py#Bar"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is True
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is True
 
         refs_a = ["src/foo.py"]
         refs_b = ["src/foo.py#Bar::baz"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is True
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is True
 
     def test_different_files_no_overlap(self):
         """References to different files never overlap."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py#Bar"]
         refs_b = ["src/baz.py#Bar"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is False
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is False
 
     def test_empty_refs_no_overlap(self):
         """Empty reference lists don't overlap."""
         from chunks import compute_symbolic_overlap
-        assert compute_symbolic_overlap([], ["src/foo.py"]) is False
-        assert compute_symbolic_overlap(["src/foo.py"], []) is False
-        assert compute_symbolic_overlap([], []) is False
+        assert compute_symbolic_overlap([], ["src/foo.py"], ".") is False
+        assert compute_symbolic_overlap(["src/foo.py"], [], ".") is False
+        assert compute_symbolic_overlap([], [], ".") is False
 
     def test_multiple_refs_any_overlap(self):
         """Multiple refs: overlap if any pair overlaps."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py#Bar", "src/baz.py#Qux"]
         refs_b = ["src/foo.py#Bar::method"]  # overlaps with refs_a[0]
-        assert compute_symbolic_overlap(refs_a, refs_b) is True
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is True
 
     def test_multiple_refs_no_overlap(self):
         """Multiple refs: no overlap if no pair overlaps."""
         from chunks import compute_symbolic_overlap
         refs_a = ["src/foo.py#Bar", "src/baz.py#Qux"]
         refs_b = ["src/foo.py#Other", "src/baz.py#Different"]
-        assert compute_symbolic_overlap(refs_a, refs_b) is False
+        assert compute_symbolic_overlap(refs_a, refs_b, ".") is False
 
 
 class TestValidateSubsystemRefs:

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from symbols import extract_symbols, parse_reference, is_parent_of
+from symbols import extract_symbols, parse_reference, is_parent_of, qualify_ref
 
 
 class TestExtractSymbols:
@@ -112,80 +112,272 @@ class TestExtractSymbols:
 
 
 class TestParseReference:
-    """Tests for parse_reference function."""
+    """Tests for parse_reference function with current_project."""
 
     def test_file_only_reference(self):
-        """File-only reference returns (file_path, None)."""
-        file_path, symbol_path = parse_reference("src/foo.py")
+        """File-only reference with current_project returns (project, file_path, None)."""
+        project, file_path, symbol_path = parse_reference("src/foo.py", current_project="local/proj")
+        assert project == "local/proj"
         assert file_path == "src/foo.py"
         assert symbol_path is None
 
     def test_class_reference(self):
-        """Class reference returns (file_path, class_name)."""
-        file_path, symbol_path = parse_reference("src/foo.py#Bar")
+        """Class reference with current_project returns (project, file_path, class_name)."""
+        project, file_path, symbol_path = parse_reference("src/foo.py#Bar", current_project="local/proj")
+        assert project == "local/proj"
         assert file_path == "src/foo.py"
         assert symbol_path == "Bar"
 
     def test_method_reference(self):
-        """Method reference returns (file_path, class::method)."""
-        file_path, symbol_path = parse_reference("src/foo.py#Bar::baz")
+        """Method reference with current_project returns (project, file_path, class::method)."""
+        project, file_path, symbol_path = parse_reference("src/foo.py#Bar::baz", current_project="local/proj")
+        assert project == "local/proj"
         assert file_path == "src/foo.py"
         assert symbol_path == "Bar::baz"
 
     def test_deeply_nested_reference(self):
         """Deeply nested reference parses correctly."""
-        file_path, symbol_path = parse_reference("src/foo.py#A::B::C::D")
+        project, file_path, symbol_path = parse_reference("src/foo.py#A::B::C::D", current_project="local/proj")
+        assert project == "local/proj"
         assert file_path == "src/foo.py"
         assert symbol_path == "A::B::C::D"
 
     def test_standalone_function_reference(self):
         """Standalone function reference parses correctly."""
-        file_path, symbol_path = parse_reference("src/utils.py#validate_input")
+        project, file_path, symbol_path = parse_reference("src/utils.py#validate_input", current_project="local/proj")
+        assert project == "local/proj"
         assert file_path == "src/utils.py"
         assert symbol_path == "validate_input"
 
+    def test_raises_without_current_project(self):
+        """Non-qualified reference without current_project raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_reference("src/foo.py")
+        assert "current_project was not provided" in str(exc_info.value)
+
 
 class TestIsParentOf:
-    """Tests for is_parent_of function."""
+    """Tests for is_parent_of function with qualified refs."""
 
     def test_file_is_parent_of_class(self):
         """File reference is parent of class in that file."""
-        assert is_parent_of("src/foo.py", "src/foo.py#Bar") is True
+        assert is_parent_of("local/proj::src/foo.py", "local/proj::src/foo.py#Bar") is True
 
     def test_file_is_parent_of_method(self):
         """File reference is parent of method in that file."""
-        assert is_parent_of("src/foo.py", "src/foo.py#Bar::baz") is True
+        assert is_parent_of("local/proj::src/foo.py", "local/proj::src/foo.py#Bar::baz") is True
 
     def test_class_is_parent_of_method(self):
         """Class reference is parent of method in that class."""
-        assert is_parent_of("src/foo.py#Bar", "src/foo.py#Bar::baz") is True
+        assert is_parent_of("local/proj::src/foo.py#Bar", "local/proj::src/foo.py#Bar::baz") is True
 
     def test_class_is_parent_of_nested_class(self):
         """Class is parent of nested class."""
-        assert is_parent_of("src/foo.py#Outer", "src/foo.py#Outer::Inner") is True
+        assert is_parent_of("local/proj::src/foo.py#Outer", "local/proj::src/foo.py#Outer::Inner") is True
 
     def test_nested_class_is_parent_of_deeper_nested(self):
         """Nested class is parent of deeper nested symbol."""
-        assert is_parent_of("src/foo.py#A::B", "src/foo.py#A::B::C") is True
+        assert is_parent_of("local/proj::src/foo.py#A::B", "local/proj::src/foo.py#A::B::C") is True
 
     def test_different_classes_not_parent(self):
         """Different classes in same file are not parent/child."""
-        assert is_parent_of("src/foo.py#Bar", "src/foo.py#Qux") is False
+        assert is_parent_of("local/proj::src/foo.py#Bar", "local/proj::src/foo.py#Qux") is False
 
     def test_different_files_not_parent(self):
         """References to different files are never parent/child."""
-        assert is_parent_of("src/foo.py#Bar", "src/baz.py#Bar") is False
-        assert is_parent_of("src/foo.py", "src/baz.py") is False
+        assert is_parent_of("local/proj::src/foo.py#Bar", "local/proj::src/baz.py#Bar") is False
+        assert is_parent_of("local/proj::src/foo.py", "local/proj::src/baz.py") is False
 
     def test_sibling_methods_not_parent(self):
         """Sibling methods are not parent/child."""
-        assert is_parent_of("src/foo.py#Bar::method1", "src/foo.py#Bar::method2") is False
+        assert is_parent_of("local/proj::src/foo.py#Bar::method1", "local/proj::src/foo.py#Bar::method2") is False
 
     def test_child_is_not_parent_of_parent(self):
         """Child reference is not parent of its own parent."""
-        assert is_parent_of("src/foo.py#Bar::baz", "src/foo.py#Bar") is False
+        assert is_parent_of("local/proj::src/foo.py#Bar::baz", "local/proj::src/foo.py#Bar") is False
 
     def test_same_reference_is_parent_of_itself(self):
         """Same reference is considered parent of itself (containment)."""
-        assert is_parent_of("src/foo.py#Bar", "src/foo.py#Bar") is True
-        assert is_parent_of("src/foo.py", "src/foo.py") is True
+        assert is_parent_of("local/proj::src/foo.py#Bar", "local/proj::src/foo.py#Bar") is True
+        assert is_parent_of("local/proj::src/foo.py", "local/proj::src/foo.py") is True
+
+    def test_unqualified_ref_raises_error(self):
+        """Unqualified ref raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            is_parent_of("src/foo.py", "src/foo.py#Bar")
+        assert "current_project was not provided" in str(exc_info.value)
+
+
+# Chunk: docs/chunks/project_qualified_refs - Project-qualified reference tests
+class TestParseReferenceWithProjectQualification:
+    """Tests for parse_reference with project-qualified paths."""
+
+    def test_project_qualified_file_only(self):
+        """Project-qualified file reference returns (project, file_path, None)."""
+        project, file_path, symbol_path = parse_reference("acme/proj::src/foo.py")
+        assert project == "acme/proj"
+        assert file_path == "src/foo.py"
+        assert symbol_path is None
+
+    def test_project_qualified_with_class(self):
+        """Project-qualified class reference returns all three parts."""
+        project, file_path, symbol_path = parse_reference("acme/proj::src/foo.py#Bar")
+        assert project == "acme/proj"
+        assert file_path == "src/foo.py"
+        assert symbol_path == "Bar"
+
+    def test_project_qualified_with_nested_symbol(self):
+        """Project-qualified nested symbol reference parses correctly."""
+        project, file_path, symbol_path = parse_reference("acme/proj::src/foo.py#Bar::baz")
+        assert project == "acme/proj"
+        assert file_path == "src/foo.py"
+        assert symbol_path == "Bar::baz"
+
+    def test_non_qualified_requires_current_project(self):
+        """Non-qualified reference without current_project raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_reference("src/foo.py#Bar")
+        assert "current_project was not provided" in str(exc_info.value)
+
+    def test_non_qualified_file_only_requires_current_project(self):
+        """Non-qualified file-only reference without current_project raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_reference("src/foo.py")
+        assert "current_project was not provided" in str(exc_info.value)
+
+    def test_current_project_inference(self):
+        """When current_project is passed, it's used for non-qualified references."""
+        project, file_path, symbol_path = parse_reference("src/foo.py#Bar", current_project="acme/proj")
+        assert project == "acme/proj"
+        assert file_path == "src/foo.py"
+        assert symbol_path == "Bar"
+
+    def test_explicit_project_overrides_current_project(self):
+        """Explicit project qualifier takes precedence over current_project."""
+        project, file_path, symbol_path = parse_reference("other/repo::src/foo.py#Bar", current_project="acme/proj")
+        assert project == "other/repo"
+        assert file_path == "src/foo.py"
+        assert symbol_path == "Bar"
+
+    def test_current_project_with_file_only(self):
+        """current_project works with file-only references."""
+        project, file_path, symbol_path = parse_reference("src/foo.py", current_project="acme/proj")
+        assert project == "acme/proj"
+        assert file_path == "src/foo.py"
+        assert symbol_path is None
+
+
+# Chunk: docs/chunks/project_qualified_refs - Project-qualified is_parent_of tests
+class TestIsParentOfWithProjectContext:
+    """Tests for is_parent_of with project-qualified references."""
+
+    def test_same_project_hierarchical_true(self):
+        """Same project + hierarchical relationship returns True."""
+        assert is_parent_of("acme/proj::src/foo.py#Bar", "acme/proj::src/foo.py#Bar::baz") is True
+
+    def test_same_project_file_parent_of_symbol(self):
+        """File reference is parent of symbols in same project."""
+        assert is_parent_of("acme/proj::src/foo.py", "acme/proj::src/foo.py#Bar") is True
+
+    def test_different_projects_same_path_false(self):
+        """Different projects with same file path are never parent/child."""
+        assert is_parent_of("acme/a::src/foo.py#Bar", "acme/b::src/foo.py#Bar") is False
+
+    def test_different_projects_never_overlap(self):
+        """Different projects never have parent/child relationship."""
+        assert is_parent_of("acme/a::src/foo.py", "acme/b::src/foo.py") is False
+        assert is_parent_of("acme/a::src/foo.py#Bar", "acme/b::src/foo.py#Bar::baz") is False
+
+    def test_non_qualified_raises_error(self):
+        """Non-qualified refs raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            is_parent_of("src/foo.py#Bar", "src/foo.py#Bar::baz")
+        assert "current_project was not provided" in str(exc_info.value)
+
+    def test_qualify_ref_then_compare(self):
+        """Use qualify_ref to prepare refs, then compare."""
+        # Qualify refs first, then pass to is_parent_of
+        ref_a = qualify_ref("src/foo.py#Bar", "acme/proj")
+        ref_b = qualify_ref("src/foo.py#Bar::baz", "acme/proj")
+        assert is_parent_of(ref_a, ref_b) is True
+
+        ref_c = qualify_ref("src/foo.py", "acme/proj")
+        ref_d = qualify_ref("src/foo.py#Bar", "acme/proj")
+        assert is_parent_of(ref_c, ref_d) is True
+
+    def test_mixed_qualified_and_unqualified_via_qualify_ref(self):
+        """Mixed refs can be compared by qualifying the unqualified one."""
+        # Explicit qualified ref
+        explicit_ref = "acme/proj::src/foo.py#Bar"
+        # Unqualified ref - qualify it to same project
+        unqualified_ref = qualify_ref("src/foo.py#Bar::baz", "acme/proj")
+        assert is_parent_of(explicit_ref, unqualified_ref) is True
+
+    def test_qualify_ref_preserves_explicit_project(self):
+        """qualify_ref preserves explicit project even with different current project."""
+        # Explicit project stays, different current project has no effect
+        ref = qualify_ref("other/repo::src/foo.py#Bar", "acme/proj")
+        assert ref == "other/repo::src/foo.py#Bar"
+        # These should not overlap (different projects)
+        ref_b = qualify_ref("src/foo.py#Bar::baz", "acme/proj")
+        assert is_parent_of(ref, ref_b) is False
+
+    def test_same_project_self_containment(self):
+        """Same reference in same project is parent of itself."""
+        assert is_parent_of("acme/proj::src/foo.py#Bar", "acme/proj::src/foo.py#Bar") is True
+
+
+# Chunk: docs/chunks/project_qualified_refs - Integration tests for overlap detection
+class TestOverlapDetectionAcrossProjects:
+    """Integration tests for overlap detection with project-qualified references."""
+
+    def test_refs_from_same_project_overlap(self):
+        """Two refs from same project correctly detect overlap."""
+        # Same project, hierarchical relationship
+        assert is_parent_of("acme/proj::src/foo.py#Bar", "acme/proj::src/foo.py#Bar::baz") is True
+        assert is_parent_of("acme/proj::src/foo.py", "acme/proj::src/foo.py#Bar") is True
+
+    def test_refs_from_different_projects_never_overlap(self):
+        """Two refs from different projects never overlap, even with identical paths."""
+        # Same file path and symbol but different projects
+        assert is_parent_of("acme/a::src/foo.py#Bar", "acme/b::src/foo.py#Bar") is False
+        assert is_parent_of("acme/a::src/foo.py#Bar", "acme/b::src/foo.py#Bar::baz") is False
+        assert is_parent_of("acme/a::src/foo.py", "acme/b::src/foo.py#Bar") is False
+
+    def test_mixed_qualified_and_unqualified_via_qualify_ref(self):
+        """Mixed refs can be compared by qualifying the unqualified one."""
+        # Unqualified ref qualified to same project - should overlap
+        qualified_parent = "acme/proj::src/foo.py#Bar"
+        qualified_child = qualify_ref("src/foo.py#Bar::baz", "acme/proj")
+        assert is_parent_of(qualified_parent, qualified_child) is True
+
+        # Different projects still don't overlap
+        other_parent = "other/repo::src/foo.py#Bar"
+        same_child = qualify_ref("src/foo.py#Bar::baz", "acme/proj")
+        assert is_parent_of(other_parent, same_child) is False
+
+    def test_both_unqualified_via_qualify_ref(self):
+        """Two unqualified refs qualified to same project behave correctly."""
+        # Both get qualified to same project, should overlap
+        ref_a = qualify_ref("src/foo.py#Bar", "acme/proj")
+        ref_b = qualify_ref("src/foo.py#Bar::baz", "acme/proj")
+        assert is_parent_of(ref_a, ref_b) is True
+
+    def test_unqualified_refs_raise_error(self):
+        """Unqualified refs raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            is_parent_of("src/foo.py#Bar", "src/foo.py#Bar::baz")
+        assert "current_project was not provided" in str(exc_info.value)
+
+    def test_no_cross_project_overlap_complex_symbols(self):
+        """Complex symbol paths don't overlap across different projects."""
+        # Deeply nested symbols in different projects
+        assert is_parent_of(
+            "org/proj-a::src/module/handler.py#Handler::process::inner",
+            "org/proj-b::src/module/handler.py#Handler::process::inner"
+        ) is False
+
+    def test_file_level_cross_project_no_overlap(self):
+        """File-level references don't overlap across projects."""
+        # File reference doesn't contain symbols from different project
+        assert is_parent_of("org/a::src/foo.py", "org/b::src/foo.py#Bar") is False


### PR DESCRIPTION
Extends SymbolicReference to support project-qualified paths in the format `org/repo::path#symbol`, enabling task-level chunks to reference code across multiple participating projects.

- parse_reference now returns (project, file_path, symbol_path) 3-tuple
- New qualify_ref function ensures refs are project-qualified before comparison
- is_parent_of requires qualified refs; different projects never overlap
- SymbolicReference validation accepts org/repo::path format
- Comprehensive unit and integration tests for all new functionality